### PR TITLE
🚀 Improve the performance of string decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,40 +57,6 @@ libraryDependencies += "com.github.tkrs" %% "fluflu-queue" % "0.5.10"
 }
 ```
 
-## Benchmarks
-
-- fluflu-msgpack
-
-Encoder
-
-```
-Benchmark                                                Mode  Cnt        Score       Error  Units
-MessagePackerBenchmark.encodeCirceAST                   thrpt   30    22302.420 ±   218.314  ops/s
-MessagePackerBenchmark.encodeInt10                      thrpt   30   156721.194 ±  1688.422  ops/s
-MessagePackerBenchmark.encodeInt30                      thrpt   30    59962.061 ±  3885.709  ops/s
-MessagePackerBenchmark.encodeLong10                     thrpt   30   146390.636 ±  5752.345  ops/s
-MessagePackerBenchmark.encodeLong30                     thrpt   30    58957.480 ±  1388.892  ops/s
-MessagePackerBenchmark.encodeString1000_30              thrpt   30     3213.112 ±    31.397  ops/s
-MessagePackerBenchmark.encodeString1000_30_multibyte    thrpt   30      782.617 ±     8.658  ops/s
-MessagePackerBenchmark.encodeString100_10               thrpt   30    60195.681 ±   545.277  ops/s
-MessagePackerBenchmark.encodeString100_30               thrpt   30    19866.150 ±   141.902  ops/s
-```
-
-Decoder
-
-```
-Benchmark                                                Mode  Cnt       Score      Error  Units
-MessageUnpackerBenchmark.decodeCirceAST                 thrpt   10   56195.041 ±  889.966  ops/s
-MessageUnpackerBenchmark.decodeInt10                    thrpt   10  203983.660 ± 7464.717  ops/s
-MessageUnpackerBenchmark.decodeInt30                    thrpt   10   56725.173 ± 2688.908  ops/s
-MessageUnpackerBenchmark.decodeLong10                   thrpt   10   64396.997 ±  588.559  ops/s
-MessageUnpackerBenchmark.decodeLong30                   thrpt   10   20645.105 ± 1467.250  ops/s
-MessageUnpackerBenchmark.decodeString1000_30            thrpt   10   23706.552 ±  365.460  ops/s
-MessageUnpackerBenchmark.decodeString1000_30_multibyte  thrpt   10    4427.903 ±   36.471  ops/s
-MessageUnpackerBenchmark.decodeString100_10             thrpt   10  153727.843 ± 5463.203  ops/s
-MessageUnpackerBenchmark.decodeString100_30             thrpt   10   46904.645 ± 1960.118  ops/s
-```
-
 ## LICENSE
 
 MIT

--- a/benchmark.txt
+++ b/benchmark.txt
@@ -1,0 +1,3299 @@
+Running org.openjdk.jmh.Main -prof gc
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessagePackerBenchmark.encodeCirceAST
+
+# Run progress: 0.00% complete, ETA 00:18:00
+# Fork: 1 of 2
+# Warmup Iteration   1: 10988.190 ops/s
+# Warmup Iteration   2: 19040.695 ops/s
+# Warmup Iteration   3: 22061.891 ops/s
+# Warmup Iteration   4: 21474.045 ops/s
+# Warmup Iteration   5: 20543.504 ops/s
+Iteration   1: 21841.975 ops/s
+                 ·gc.alloc.rate:                   657.114 MB/sec
+                 ·gc.alloc.rate.norm:              34728.005 B/op
+                 ·gc.churn.PS_Eden_Space:          666.329 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     35215.002 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.062 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.297 B/op
+                 ·gc.count:                        35.000 counts
+                 ·gc.time:                         16.000 ms
+
+Iteration   2: 21135.057 ops/s
+                 ·gc.alloc.rate:                   635.752 MB/sec
+                 ·gc.alloc.rate.norm:              34728.004 B/op
+                 ·gc.churn.PS_Eden_Space:          636.860 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34788.499 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 9.301 B/op
+                 ·gc.count:                        87.000 counts
+                 ·gc.time:                         42.000 ms
+
+Iteration   3: 21784.241 ops/s
+                 ·gc.alloc.rate:                   655.587 MB/sec
+                 ·gc.alloc.rate.norm:              34728.004 B/op
+                 ·gc.churn.PS_Eden_Space:          655.569 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34727.042 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.153 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 8.107 B/op
+                 ·gc.count:                        94.000 counts
+                 ·gc.time:                         45.000 ms
+
+Iteration   4: 21508.222 ops/s
+                 ·gc.alloc.rate:                   647.033 MB/sec
+                 ·gc.alloc.rate.norm:              34728.004 B/op
+                 ·gc.churn.PS_Eden_Space:          652.088 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34999.287 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.125 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 6.701 B/op
+                 ·gc.count:                        92.000 counts
+                 ·gc.time:                         43.000 ms
+
+Iteration   5: 21314.106 ops/s
+                 ·gc.alloc.rate:                   641.646 MB/sec
+                 ·gc.alloc.rate.norm:              34728.004 B/op
+                 ·gc.churn.PS_Eden_Space:          638.570 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34561.524 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.142 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 7.682 B/op
+                 ·gc.count:                        99.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+# Run progress: 2.78% complete, ETA 00:20:55
+# Fork: 2 of 2
+# Warmup Iteration   1: 14001.664 ops/s
+# Warmup Iteration   2: 20363.234 ops/s
+# Warmup Iteration   3: 17867.729 ops/s
+# Warmup Iteration   4: 22288.516 ops/s
+# Warmup Iteration   5: 22590.044 ops/s
+Iteration   1: 22759.586 ops/s
+                 ·gc.alloc.rate:                   665.515 MB/sec
+                 ·gc.alloc.rate.norm:              33738.784 B/op
+                 ·gc.churn.PS_Eden_Space:          695.517 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     35259.754 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.023 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.151 B/op
+                 ·gc.count:                        11.000 counts
+                 ·gc.time:                         6.000 ms
+
+Iteration   2: 22402.934 ops/s
+                 ·gc.alloc.rate:                   654.861 MB/sec
+                 ·gc.alloc.rate.norm:              33736.004 B/op
+                 ·gc.churn.PS_Eden_Space:          647.486 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     33356.039 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.034 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.754 B/op
+                 ·gc.count:                        18.000 counts
+                 ·gc.time:                         10.000 ms
+
+Iteration   3: 22364.301 ops/s
+                 ·gc.alloc.rate:                   653.667 MB/sec
+                 ·gc.alloc.rate.norm:              33736.004 B/op
+                 ·gc.churn.PS_Eden_Space:          675.683 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34872.258 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.108 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 5.562 B/op
+                 ·gc.count:                        47.000 counts
+                 ·gc.time:                         23.000 ms
+
+Iteration   4: 22691.238 ops/s
+                 ·gc.alloc.rate:                   663.196 MB/sec
+                 ·gc.alloc.rate.norm:              33736.004 B/op
+                 ·gc.churn.PS_Eden_Space:          659.577 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     33551.940 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 8.659 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         43.000 ms
+
+Iteration   5: 22193.157 ops/s
+                 ·gc.alloc.rate:                   648.757 MB/sec
+                 ·gc.alloc.rate.norm:              33736.004 B/op
+                 ·gc.churn.PS_Eden_Space:          656.352 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34130.924 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.153 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 7.965 B/op
+                 ·gc.count:                        102.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+
+Result "fluflu.msgpack.MessagePackerBenchmark.encodeCirceAST":
+  21999.482 ±(99.9%) 861.022 ops/s [Average]
+  (min, avg, max) = (21135.057, 21999.482, 22759.586), stdev = 569.513
+  CI (99.9%): [21138.459, 22860.504] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeCirceAST:·gc.alloc.rate":
+  652.313 ±(99.9%) 13.924 MB/sec [Average]
+  (min, avg, max) = (635.752, 652.313, 665.515), stdev = 9.210
+  CI (99.9%): [638.389, 666.237] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeCirceAST:·gc.alloc.rate.norm":
+  34232.282 ±(99.9%) 790.003 B/op [Average]
+  (min, avg, max) = (33736.004, 34232.282, 34728.005), stdev = 522.538
+  CI (99.9%): [33442.280, 35022.285] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Eden_Space":
+  658.403 ±(99.9%) 26.519 MB/sec [Average]
+  (min, avg, max) = (636.860, 658.403, 695.517), stdev = 17.541
+  CI (99.9%): [631.884, 684.922] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Eden_Space.norm":
+  34546.227 ±(99.9%) 999.961 B/op [Average]
+  (min, avg, max) = (33356.039, 34546.227, 35259.754), stdev = 661.412
+  CI (99.9%): [33546.266, 35546.188] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Survivor_Space":
+  0.114 ±(99.9%) 0.084 MB/sec [Average]
+  (min, avg, max) = (0.023, 0.114, 0.170), stdev = 0.055
+  CI (99.9%): [0.030, 0.198] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Survivor_Space.norm":
+  6.018 ±(99.9%) 4.469 B/op [Average]
+  (min, avg, max) = (1.151, 6.018, 9.301), stdev = 2.956
+  CI (99.9%): [1.549, 10.486] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeCirceAST:·gc.count":
+  674.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (11.000, 67.400, 102.000), stdev = 35.663
+  CI (99.9%): [674.000, 674.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeCirceAST:·gc.time":
+  322.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (6.000, 32.200, 47.000), stdev = 16.525
+  CI (99.9%): [322.000, 322.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessagePackerBenchmark.encodeInt10
+
+# Run progress: 5.56% complete, ETA 00:20:19
+# Fork: 1 of 2
+# Warmup Iteration   1: 52365.323 ops/s
+# Warmup Iteration   2: 120851.787 ops/s
+# Warmup Iteration   3: 146728.712 ops/s
+# Warmup Iteration   4: 156618.004 ops/s
+# Warmup Iteration   5: 158473.795 ops/s
+Iteration   1: 154420.387 ops/s
+                 ·gc.alloc.rate:                   1351.557 MB/sec
+                 ·gc.alloc.rate.norm:              10096.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1363.857 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10187.881 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.074 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.551 B/op
+                 ·gc.count:                        51.000 counts
+                 ·gc.time:                         24.000 ms
+
+Iteration   2: 150504.423 ops/s
+                 ·gc.alloc.rate:                   1316.893 MB/sec
+                 ·gc.alloc.rate.norm:              10096.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1319.060 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10112.613 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.142 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.088 B/op
+                 ·gc.count:                        102.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   3: 152885.144 ops/s
+                 ·gc.alloc.rate:                   1337.485 MB/sec
+                 ·gc.alloc.rate.norm:              10096.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1339.272 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10109.489 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.176 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.328 B/op
+                 ·gc.count:                        101.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   4: 156097.417 ops/s
+                 ·gc.alloc.rate:                   1365.231 MB/sec
+                 ·gc.alloc.rate.norm:              10096.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1363.899 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10086.152 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.142 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.049 B/op
+                 ·gc.count:                        103.000 counts
+                 ·gc.time:                         49.000 ms
+
+Iteration   5: 155296.640 ops/s
+                 ·gc.alloc.rate:                   1358.890 MB/sec
+                 ·gc.alloc.rate.norm:              10096.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1354.548 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10063.741 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.187 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.391 B/op
+                 ·gc.count:                        98.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+# Run progress: 8.33% complete, ETA 00:19:45
+# Fork: 2 of 2
+# Warmup Iteration   1: 47246.599 ops/s
+# Warmup Iteration   2: 129285.656 ops/s
+# Warmup Iteration   3: 161584.618 ops/s
+# Warmup Iteration   4: 156126.679 ops/s
+# Warmup Iteration   5: 158773.053 ops/s
+Iteration   1: 155864.529 ops/s
+                 ·gc.alloc.rate:                   1385.102 MB/sec
+                 ·gc.alloc.rate.norm:              10256.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1390.194 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10293.704 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.119 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.882 B/op
+                 ·gc.count:                        57.000 counts
+                 ·gc.time:                         28.000 ms
+
+Iteration   2: 154262.503 ops/s
+                 ·gc.alloc.rate:                   1370.528 MB/sec
+                 ·gc.alloc.rate.norm:              10256.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1377.281 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10306.533 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.153 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.146 B/op
+                 ·gc.count:                        99.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   3: 157298.258 ops/s
+                 ·gc.alloc.rate:                   1398.061 MB/sec
+                 ·gc.alloc.rate.norm:              10256.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1391.464 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10207.605 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.187 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.374 B/op
+                 ·gc.count:                        99.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   4: 154195.856 ops/s
+                 ·gc.alloc.rate:                   1370.376 MB/sec
+                 ·gc.alloc.rate.norm:              10256.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1370.551 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10257.314 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.187 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.402 B/op
+                 ·gc.count:                        101.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 156732.130 ops/s
+                 ·gc.alloc.rate:                   1393.528 MB/sec
+                 ·gc.alloc.rate.norm:              10256.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1392.839 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10250.931 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.227 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.672 B/op
+                 ·gc.count:                        98.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+
+Result "fluflu.msgpack.MessagePackerBenchmark.encodeInt10":
+  154755.729 ±(99.9%) 3020.968 ops/s [Average]
+  (min, avg, max) = (150504.423, 154755.729, 157298.258), stdev = 1998.184
+  CI (99.9%): [151734.760, 157776.697] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt10:·gc.alloc.rate":
+  1364.765 ±(99.9%) 37.912 MB/sec [Average]
+  (min, avg, max) = (1316.893, 1364.765, 1398.061), stdev = 25.076
+  CI (99.9%): [1326.854, 1402.677] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt10:·gc.alloc.rate.norm":
+  10176.001 ±(99.9%) 127.491 B/op [Average]
+  (min, avg, max) = (10096.001, 10176.001, 10256.001), stdev = 84.327
+  CI (99.9%): [10048.510, 10303.492] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Eden_Space":
+  1366.297 ±(99.9%) 36.197 MB/sec [Average]
+  (min, avg, max) = (1319.060, 1366.297, 1392.839), stdev = 23.942
+  CI (99.9%): [1330.099, 1402.494] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Eden_Space.norm":
+  10187.596 ±(99.9%) 135.254 B/op [Average]
+  (min, avg, max) = (10063.741, 10187.596, 10306.533), stdev = 89.462
+  CI (99.9%): [10052.343, 10322.850] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Survivor_Space":
+  0.159 ±(99.9%) 0.065 MB/sec [Average]
+  (min, avg, max) = (0.074, 0.159, 0.227), stdev = 0.043
+  CI (99.9%): [0.094, 0.225] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Survivor_Space.norm":
+  1.188 ±(99.9%) 0.480 B/op [Average]
+  (min, avg, max) = (0.551, 1.188, 1.672), stdev = 0.317
+  CI (99.9%): [0.709, 1.668] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt10:·gc.count":
+  909.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (51.000, 90.900, 103.000), stdev = 19.570
+  CI (99.9%): [909.000, 909.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt10:·gc.time":
+  434.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (24.000, 43.400, 49.000), stdev = 9.240
+  CI (99.9%): [434.000, 434.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessagePackerBenchmark.encodeInt30
+
+# Run progress: 11.11% complete, ETA 00:19:08
+# Fork: 1 of 2
+# Warmup Iteration   1: 16324.884 ops/s
+# Warmup Iteration   2: 47367.948 ops/s
+# Warmup Iteration   3: 62112.373 ops/s
+# Warmup Iteration   4: 65320.361 ops/s
+# Warmup Iteration   5: 62119.285 ops/s
+Iteration   1: 62116.156 ops/s
+                 ·gc.alloc.rate:                   1324.434 MB/sec
+                 ·gc.alloc.rate.norm:              24607.801 B/op
+                 ·gc.churn.PS_Eden_Space:          1361.094 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     25288.944 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.085 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.582 B/op
+                 ·gc.count:                        47.000 counts
+                 ·gc.time:                         23.000 ms
+
+Iteration   2: 62516.515 ops/s
+                 ·gc.alloc.rate:                   1332.399 MB/sec
+                 ·gc.alloc.rate.norm:              24596.969 B/op
+                 ·gc.churn.PS_Eden_Space:          1334.114 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     24628.640 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.187 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.457 B/op
+                 ·gc.count:                        103.000 counts
+                 ·gc.time:                         49.000 ms
+
+Iteration   3: 62649.977 ops/s
+                 ·gc.alloc.rate:                   1333.578 MB/sec
+                 ·gc.alloc.rate.norm:              24571.856 B/op
+                 ·gc.churn.PS_Eden_Space:          1330.329 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     24511.988 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.135 B/op
+                 ·gc.count:                        91.000 counts
+                 ·gc.time:                         45.000 ms
+
+Iteration   4: 63383.592 ops/s
+                 ·gc.alloc.rate:                   1350.990 MB/sec
+                 ·gc.alloc.rate.norm:              24586.446 B/op
+                 ·gc.churn.PS_Eden_Space:          1345.197 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     24481.010 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.099 B/op
+                 ·gc.count:                        98.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   5: 62563.269 ops/s
+                 ·gc.alloc.rate:                   1332.922 MB/sec
+                 ·gc.alloc.rate.norm:              24585.701 B/op
+                 ·gc.churn.PS_Eden_Space:          1338.799 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     24694.105 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.125 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.304 B/op
+                 ·gc.count:                        94.000 counts
+                 ·gc.time:                         46.000 ms
+
+
+# Run progress: 13.89% complete, ETA 00:18:32
+# Fork: 2 of 2
+# Warmup Iteration   1: 15643.628 ops/s
+# Warmup Iteration   2: 50682.460 ops/s
+# Warmup Iteration   3: 66013.111 ops/s
+# Warmup Iteration   4: 65579.839 ops/s
+# Warmup Iteration   5: 63770.451 ops/s
+Iteration   1: 63839.229 ops/s
+                 ·gc.alloc.rate:                   1359.035 MB/sec
+                 ·gc.alloc.rate.norm:              24568.962 B/op
+                 ·gc.churn.PS_Eden_Space:          1373.897 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     24837.648 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.085 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.538 B/op
+                 ·gc.count:                        52.000 counts
+                 ·gc.time:                         25.000 ms
+
+Iteration   2: 63726.637 ops/s
+                 ·gc.alloc.rate:                   1354.768 MB/sec
+                 ·gc.alloc.rate.norm:              24534.899 B/op
+                 ·gc.churn.PS_Eden_Space:          1347.976 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     24411.900 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.187 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.390 B/op
+                 ·gc.count:                        100.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   3: 63503.178 ops/s
+                 ·gc.alloc.rate:                   1350.516 MB/sec
+                 ·gc.alloc.rate.norm:              24550.560 B/op
+                 ·gc.churn.PS_Eden_Space:          1356.956 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     24667.639 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.182 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.300 B/op
+                 ·gc.count:                        103.000 counts
+                 ·gc.time:                         49.000 ms
+
+Iteration   4: 62696.757 ops/s
+                 ·gc.alloc.rate:                   1334.485 MB/sec
+                 ·gc.alloc.rate.norm:              24565.167 B/op
+                 ·gc.churn.PS_Eden_Space:          1329.981 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     24482.248 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.165 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.031 B/op
+                 ·gc.count:                        93.000 counts
+                 ·gc.time:                         46.000 ms
+
+Iteration   5: 59941.065 ops/s
+                 ·gc.alloc.rate:                   1273.861 MB/sec
+                 ·gc.alloc.rate.norm:              24532.096 B/op
+                 ·gc.churn.PS_Eden_Space:          1255.009 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     24169.038 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.142 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.730 B/op
+                 ·gc.count:                        80.000 counts
+                 ·gc.time:                         50.000 ms
+
+
+
+Result "fluflu.msgpack.MessagePackerBenchmark.encodeInt30":
+  62693.637 ±(99.9%) 1706.851 ops/s [Average]
+  (min, avg, max) = (59941.065, 62693.637, 63839.229), stdev = 1128.976
+  CI (99.9%): [60986.786, 64400.489] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt30:·gc.alloc.rate":
+  1334.699 ±(99.9%) 36.782 MB/sec [Average]
+  (min, avg, max) = (1273.861, 1334.699, 1359.035), stdev = 24.329
+  CI (99.9%): [1297.917, 1371.480] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt30:·gc.alloc.rate.norm":
+  24570.046 ±(99.9%) 38.206 B/op [Average]
+  (min, avg, max) = (24532.096, 24570.046, 24607.801), stdev = 25.271
+  CI (99.9%): [24531.839, 24608.252] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Eden_Space":
+  1337.335 ±(99.9%) 48.742 MB/sec [Average]
+  (min, avg, max) = (1255.009, 1337.335, 1373.897), stdev = 32.240
+  CI (99.9%): [1288.593, 1386.077] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Eden_Space.norm":
+  24617.316 ±(99.9%) 450.538 B/op [Average]
+  (min, avg, max) = (24169.038, 24617.316, 25288.944), stdev = 298.003
+  CI (99.9%): [24166.778, 25067.854] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Survivor_Space":
+  0.150 ±(99.9%) 0.059 MB/sec [Average]
+  (min, avg, max) = (0.085, 0.150, 0.187), stdev = 0.039
+  CI (99.9%): [0.090, 0.209] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Survivor_Space.norm":
+  2.757 ±(99.9%) 1.080 B/op [Average]
+  (min, avg, max) = (1.538, 2.757, 3.457), stdev = 0.714
+  CI (99.9%): [1.677, 3.837] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt30:·gc.count":
+  861.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (47.000, 86.100, 103.000), stdev = 20.464
+  CI (99.9%): [861.000, 861.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeInt30:·gc.time":
+  428.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (23.000, 42.800, 50.000), stdev = 10.042
+  CI (99.9%): [428.000, 428.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessagePackerBenchmark.encodeLong10
+
+# Run progress: 16.67% complete, ETA 00:17:56
+# Fork: 1 of 2
+# Warmup Iteration   1: 13962.281 ops/s
+# Warmup Iteration   2: 133732.586 ops/s
+# Warmup Iteration   3: 129660.247 ops/s
+# Warmup Iteration   4: 78938.112 ops/s
+# Warmup Iteration   5: 129005.682 ops/s
+Iteration   1: 144405.165 ops/s
+                 ·gc.alloc.rate:                   1177.279 MB/sec
+                 ·gc.alloc.rate.norm:              9407.840 B/op
+                 ·gc.churn.PS_Eden_Space:          1141.053 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     9118.349 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.023 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.181 B/op
+                 ·gc.count:                        11.000 counts
+                 ·gc.time:                         8.000 ms
+
+Iteration   2: 154625.503 ops/s
+                 ·gc.alloc.rate:                   1258.583 MB/sec
+                 ·gc.alloc.rate.norm:              9395.480 B/op
+                 ·gc.churn.PS_Eden_Space:          1271.834 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     9494.397 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.051 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.381 B/op
+                 ·gc.count:                        26.000 counts
+                 ·gc.time:                         17.000 ms
+
+Iteration   3: 146821.579 ops/s
+                 ·gc.alloc.rate:                   1195.544 MB/sec
+                 ·gc.alloc.rate.norm:              9395.618 B/op
+                 ·gc.churn.PS_Eden_Space:          1200.657 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     9435.800 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.148 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.159 B/op
+                 ·gc.count:                        81.000 counts
+                 ·gc.time:                         40.000 ms
+
+Iteration   4: 166216.222 ops/s
+                 ·gc.alloc.rate:                   1352.686 MB/sec
+                 ·gc.alloc.rate.norm:              9392.701 B/op
+                 ·gc.churn.PS_Eden_Space:          1355.483 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     9412.122 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.159 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.103 B/op
+                 ·gc.count:                        92.000 counts
+                 ·gc.time:                         44.000 ms
+
+Iteration   5: 167295.169 ops/s
+                 ·gc.alloc.rate:                   1361.319 MB/sec
+                 ·gc.alloc.rate.norm:              9392.060 B/op
+                 ·gc.churn.PS_Eden_Space:          1363.637 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     9408.052 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.174 B/op
+                 ·gc.count:                        104.000 counts
+                 ·gc.time:                         49.000 ms
+
+
+# Run progress: 19.44% complete, ETA 00:17:21
+# Fork: 2 of 2
+# Warmup Iteration   1: 36137.163 ops/s
+# Warmup Iteration   2: 117344.945 ops/s
+# Warmup Iteration   3: 152833.007 ops/s
+# Warmup Iteration   4: 153801.726 ops/s
+# Warmup Iteration   5: 155801.726 ops/s
+Iteration   1: 139355.953 ops/s
+                 ·gc.alloc.rate:                   1241.577 MB/sec
+                 ·gc.alloc.rate.norm:              10296.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1283.308 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10642.056 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.091 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.752 B/op
+                 ·gc.count:                        47.000 counts
+                 ·gc.time:                         27.000 ms
+
+Iteration   2: 144606.470 ops/s
+                 ·gc.alloc.rate:                   1289.620 MB/sec
+                 ·gc.alloc.rate.norm:              10296.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1274.720 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10177.039 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.159 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.267 B/op
+                 ·gc.count:                        90.000 counts
+                 ·gc.time:                         45.000 ms
+
+Iteration   3: 152353.599 ops/s
+                 ·gc.alloc.rate:                   1358.076 MB/sec
+                 ·gc.alloc.rate.norm:              10296.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1377.963 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10446.771 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.181 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.374 B/op
+                 ·gc.count:                        98.000 counts
+                 ·gc.time:                         46.000 ms
+
+Iteration   4: 149435.643 ops/s
+                 ·gc.alloc.rate:                   1332.845 MB/sec
+                 ·gc.alloc.rate.norm:              10296.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1325.727 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10241.013 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.199 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.534 B/op
+                 ·gc.count:                        96.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 146265.950 ops/s
+                 ·gc.alloc.rate:                   1304.006 MB/sec
+                 ·gc.alloc.rate.norm:              10296.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1299.455 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10260.071 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.147 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.164 B/op
+                 ·gc.count:                        90.000 counts
+                 ·gc.time:                         44.000 ms
+
+
+
+Result "fluflu.msgpack.MessagePackerBenchmark.encodeLong10":
+  151138.125 ±(99.9%) 14021.495 ops/s [Average]
+  (min, avg, max) = (139355.953, 151138.125, 167295.169), stdev = 9274.351
+  CI (99.9%): [137116.631, 165159.620] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong10:·gc.alloc.rate":
+  1287.154 ±(99.9%) 101.495 MB/sec [Average]
+  (min, avg, max) = (1177.279, 1287.154, 1361.319), stdev = 67.133
+  CI (99.9%): [1185.659, 1388.648] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong10:·gc.alloc.rate.norm":
+  9846.370 ±(99.9%) 716.577 B/op [Average]
+  (min, avg, max) = (9392.060, 9846.370, 10296.001), stdev = 473.971
+  CI (99.9%): [9129.793, 10562.947] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Eden_Space":
+  1289.384 ±(99.9%) 112.219 MB/sec [Average]
+  (min, avg, max) = (1141.053, 1289.384, 1377.963), stdev = 74.226
+  CI (99.9%): [1177.164, 1401.603] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Eden_Space.norm":
+  9863.567 ±(99.9%) 817.279 B/op [Average]
+  (min, avg, max) = (9118.349, 9863.567, 10642.056), stdev = 540.580
+  CI (99.9%): [9046.288, 10680.846] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Survivor_Space":
+  0.133 ±(99.9%) 0.088 MB/sec [Average]
+  (min, avg, max) = (0.023, 0.133, 0.199), stdev = 0.058
+  CI (99.9%): [0.045, 0.221] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Survivor_Space.norm":
+  1.009 ±(99.9%) 0.658 B/op [Average]
+  (min, avg, max) = (0.181, 1.009, 1.534), stdev = 0.435
+  CI (99.9%): [0.351, 1.667] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong10:·gc.count":
+  735.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (11.000, 73.500, 104.000), stdev = 33.073
+  CI (99.9%): [735.000, 735.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong10:·gc.time":
+  368.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (8.000, 36.800, 49.000), stdev = 14.367
+  CI (99.9%): [368.000, 368.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessagePackerBenchmark.encodeLong30
+
+# Run progress: 22.22% complete, ETA 00:16:45
+# Fork: 1 of 2
+# Warmup Iteration   1: 11813.277 ops/s
+# Warmup Iteration   2: 35291.770 ops/s
+# Warmup Iteration   3: 51273.186 ops/s
+# Warmup Iteration   4: 55085.993 ops/s
+# Warmup Iteration   5: 53933.058 ops/s
+Iteration   1: 53160.272 ops/s
+                 ·gc.alloc.rate:                   1362.444 MB/sec
+                 ·gc.alloc.rate.norm:              29608.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1371.608 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     29807.139 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.119 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.586 B/op
+                 ·gc.count:                        56.000 counts
+                 ·gc.time:                         30.000 ms
+
+Iteration   2: 53564.186 ops/s
+                 ·gc.alloc.rate:                   1372.793 MB/sec
+                 ·gc.alloc.rate.norm:              29608.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1369.565 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     29538.398 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.187 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 4.030 B/op
+                 ·gc.count:                        97.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   3: 53312.123 ops/s
+                 ·gc.alloc.rate:                   1366.402 MB/sec
+                 ·gc.alloc.rate.norm:              29608.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1366.837 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     29617.429 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.682 B/op
+                 ·gc.count:                        92.000 counts
+                 ·gc.time:                         46.000 ms
+
+Iteration   4: 53649.631 ops/s
+                 ·gc.alloc.rate:                   1375.529 MB/sec
+                 ·gc.alloc.rate.norm:              29608.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1376.177 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     29621.958 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.204 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 4.391 B/op
+                 ·gc.count:                        100.000 counts
+                 ·gc.time:                         49.000 ms
+
+Iteration   5: 52635.915 ops/s
+                 ·gc.alloc.rate:                   1349.377 MB/sec
+                 ·gc.alloc.rate.norm:              29608.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1348.817 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     29595.715 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.176 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.854 B/op
+                 ·gc.count:                        100.000 counts
+                 ·gc.time:                         49.000 ms
+
+
+# Run progress: 25.00% complete, ETA 00:16:10
+# Fork: 2 of 2
+# Warmup Iteration   1: 18781.197 ops/s
+# Warmup Iteration   2: 29925.266 ops/s
+# Warmup Iteration   3: 48162.302 ops/s
+# Warmup Iteration   4: 57644.519 ops/s
+# Warmup Iteration   5: 57577.556 ops/s
+Iteration   1: 58388.499 ops/s
+                 ·gc.alloc.rate:                   1503.734 MB/sec
+                 ·gc.alloc.rate.norm:              29729.266 B/op
+                 ·gc.churn.PS_Eden_Space:          1536.660 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     30380.233 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.045 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.896 B/op
+                 ·gc.count:                        19.000 counts
+                 ·gc.time:                         13.000 ms
+
+Iteration   2: 56866.243 ops/s
+                 ·gc.alloc.rate:                   1466.686 MB/sec
+                 ·gc.alloc.rate.norm:              29764.806 B/op
+                 ·gc.churn.PS_Eden_Space:          1480.362 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     30042.347 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.119 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.416 B/op
+                 ·gc.count:                        64.000 counts
+                 ·gc.time:                         31.000 ms
+
+Iteration   3: 58120.723 ops/s
+                 ·gc.alloc.rate:                   1497.576 MB/sec
+                 ·gc.alloc.rate.norm:              29753.331 B/op
+                 ·gc.churn.PS_Eden_Space:          1508.600 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     29972.337 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.119 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.365 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         45.000 ms
+
+Iteration   4: 58027.391 ops/s
+                 ·gc.alloc.rate:                   1494.258 MB/sec
+                 ·gc.alloc.rate.norm:              29753.589 B/op
+                 ·gc.churn.PS_Eden_Space:          1494.509 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     29758.589 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.193 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.836 B/op
+                 ·gc.count:                        99.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 57628.964 ops/s
+                 ·gc.alloc.rate:                   1485.683 MB/sec
+                 ·gc.alloc.rate.norm:              29749.399 B/op
+                 ·gc.churn.PS_Eden_Space:          1475.700 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     29549.502 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.193 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.860 B/op
+                 ·gc.count:                        93.000 counts
+                 ·gc.time:                         46.000 ms
+
+
+
+Result "fluflu.msgpack.MessagePackerBenchmark.encodeLong30":
+  55535.395 ±(99.9%) 3690.269 ops/s [Average]
+  (min, avg, max) = (52635.915, 55535.395, 58388.499), stdev = 2440.884
+  CI (99.9%): [51845.126, 59225.664] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong30:·gc.alloc.rate":
+  1427.448 ±(99.9%) 100.616 MB/sec [Average]
+  (min, avg, max) = (1349.377, 1427.448, 1503.734), stdev = 66.551
+  CI (99.9%): [1326.832, 1528.064] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong30:·gc.alloc.rate.norm":
+  29679.040 ±(99.9%) 113.962 B/op [Average]
+  (min, avg, max) = (29608.002, 29679.040, 29764.806), stdev = 75.379
+  CI (99.9%): [29565.078, 29793.002] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Eden_Space":
+  1432.884 ±(99.9%) 109.017 MB/sec [Average]
+  (min, avg, max) = (1348.817, 1432.884, 1536.660), stdev = 72.108
+  CI (99.9%): [1323.866, 1541.901] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Eden_Space.norm":
+  29788.365 ±(99.9%) 410.485 B/op [Average]
+  (min, avg, max) = (29538.398, 29788.365, 30380.233), stdev = 271.511
+  CI (99.9%): [29377.879, 30198.850] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Survivor_Space":
+  0.152 ±(99.9%) 0.076 MB/sec [Average]
+  (min, avg, max) = (0.045, 0.152, 0.204), stdev = 0.050
+  CI (99.9%): [0.076, 0.228] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Survivor_Space.norm":
+  3.192 ±(99.9%) 1.641 B/op [Average]
+  (min, avg, max) = (0.896, 3.192, 4.391), stdev = 1.085
+  CI (99.9%): [1.550, 4.833] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong30:·gc.count":
+  809.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (19.000, 80.900, 100.000), stdev = 26.644
+  CI (99.9%): [809.000, 809.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeLong30:·gc.time":
+  404.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (13.000, 40.400, 49.000), stdev = 11.928
+  CI (99.9%): [404.000, 404.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30
+
+# Run progress: 27.78% complete, ETA 00:15:34
+# Fork: 1 of 2
+# Warmup Iteration   1: 1948.135 ops/s
+# Warmup Iteration   2: 2644.676 ops/s
+# Warmup Iteration   3: 3066.813 ops/s
+# Warmup Iteration   4: 3137.950 ops/s
+# Warmup Iteration   5: 2991.044 ops/s
+Iteration   1: 3114.796 ops/s
+                 ·gc.alloc.rate:                   482.952 MB/sec
+                 ·gc.alloc.rate.norm:              178832.030 B/op
+                 ·gc.churn.PS_Eden_Space:          482.582 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     178694.827 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.048 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 17.857 B/op
+                 ·gc.count:                        18.000 counts
+                 ·gc.time:                         9.000 ms
+
+Iteration   2: 3124.733 ops/s
+                 ·gc.alloc.rate:                   484.485 MB/sec
+                 ·gc.alloc.rate.norm:              178832.030 B/op
+                 ·gc.churn.PS_Eden_Space:          495.092 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     182747.031 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.079 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 29.319 B/op
+                 ·gc.count:                        39.000 counts
+                 ·gc.time:                         19.000 ms
+
+Iteration   3: 3133.583 ops/s
+                 ·gc.alloc.rate:                   485.350 MB/sec
+                 ·gc.alloc.rate.norm:              178832.028 B/op
+                 ·gc.churn.PS_Eden_Space:          490.446 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     180709.821 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.210 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 77.323 B/op
+                 ·gc.count:                        81.000 counts
+                 ·gc.time:                         37.000 ms
+
+Iteration   4: 3078.040 ops/s
+                 ·gc.alloc.rate:                   476.462 MB/sec
+                 ·gc.alloc.rate.norm:              178855.041 B/op
+                 ·gc.churn.PS_Eden_Space:          475.457 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     178477.979 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.184 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 69.132 B/op
+                 ·gc.count:                        86.000 counts
+                 ·gc.time:                         41.000 ms
+
+Iteration   5: 3141.872 ops/s
+                 ·gc.alloc.rate:                   486.874 MB/sec
+                 ·gc.alloc.rate.norm:              178856.029 B/op
+                 ·gc.churn.PS_Eden_Space:          486.825 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     178838.278 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.147 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 54.160 B/op
+                 ·gc.count:                        88.000 counts
+                 ·gc.time:                         41.000 ms
+
+
+# Run progress: 30.56% complete, ETA 00:14:58
+# Fork: 2 of 2
+# Warmup Iteration   1: 1974.106 ops/s
+# Warmup Iteration   2: 2880.222 ops/s
+# Warmup Iteration   3: 2957.925 ops/s
+# Warmup Iteration   4: 3164.373 ops/s
+# Warmup Iteration   5: 2975.914 ops/s
+Iteration   1: 3177.950 ops/s
+                 ·gc.alloc.rate:                   492.080 MB/sec
+                 ·gc.alloc.rate.norm:              178848.029 B/op
+                 ·gc.churn.PS_Eden_Space:          502.140 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     182504.481 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.045 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 16.501 B/op
+                 ·gc.count:                        19.000 counts
+                 ·gc.time:                         9.000 ms
+
+Iteration   2: 3178.621 ops/s
+                 ·gc.alloc.rate:                   492.574 MB/sec
+                 ·gc.alloc.rate.norm:              178848.027 B/op
+                 ·gc.churn.PS_Eden_Space:          499.797 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     181470.374 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.105 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 38.090 B/op
+                 ·gc.count:                        41.000 counts
+                 ·gc.time:                         20.000 ms
+
+Iteration   3: 3100.595 ops/s
+                 ·gc.alloc.rate:                   480.256 MB/sec
+                 ·gc.alloc.rate.norm:              178848.030 B/op
+                 ·gc.churn.PS_Eden_Space:          482.065 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     179521.557 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.178 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 66.470 B/op
+                 ·gc.count:                        81.000 counts
+                 ·gc.time:                         39.000 ms
+
+Iteration   4: 3163.128 ops/s
+                 ·gc.alloc.rate:                   489.790 MB/sec
+                 ·gc.alloc.rate.norm:              178871.944 B/op
+                 ·gc.churn.PS_Eden_Space:          492.154 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     179735.280 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.184 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 67.269 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         43.000 ms
+
+Iteration   5: 3109.208 ops/s
+                 ·gc.alloc.rate:                   481.476 MB/sec
+                 ·gc.alloc.rate.norm:              178872.030 B/op
+                 ·gc.churn.PS_Eden_Space:          480.772 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     178610.631 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.164 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 61.021 B/op
+                 ·gc.count:                        87.000 counts
+                 ·gc.time:                         42.000 ms
+
+
+
+Result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30":
+  3132.253 ±(99.9%) 50.695 ops/s [Average]
+  (min, avg, max) = (3078.040, 3132.253, 3178.621), stdev = 33.532
+  CI (99.9%): [3081.557, 3182.948] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30:·gc.alloc.rate":
+  485.230 ±(99.9%) 7.901 MB/sec [Average]
+  (min, avg, max) = (476.462, 485.230, 492.574), stdev = 5.226
+  CI (99.9%): [477.328, 493.131] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30:·gc.alloc.rate.norm":
+  178849.522 ±(99.9%) 22.576 B/op [Average]
+  (min, avg, max) = (178832.028, 178849.522, 178872.030), stdev = 14.933
+  CI (99.9%): [178826.946, 178872.098] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Eden_Space":
+  488.733 ±(99.9%) 13.168 MB/sec [Average]
+  (min, avg, max) = (475.457, 488.733, 502.140), stdev = 8.710
+  CI (99.9%): [475.564, 501.901] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Eden_Space.norm":
+  180131.026 ±(99.9%) 2464.308 B/op [Average]
+  (min, avg, max) = (178477.979, 180131.026, 182747.031), stdev = 1629.987
+  CI (99.9%): [177666.718, 182595.334] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Survivor_Space":
+  0.135 ±(99.9%) 0.091 MB/sec [Average]
+  (min, avg, max) = (0.045, 0.135, 0.210), stdev = 0.060
+  CI (99.9%): [0.043, 0.226] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Survivor_Space.norm":
+  49.714 ±(99.9%) 33.974 B/op [Average]
+  (min, avg, max) = (16.501, 49.714, 77.323), stdev = 22.472
+  CI (99.9%): [15.740, 83.689] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30:·gc.count":
+  629.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (18.000, 62.900, 89.000), stdev = 29.953
+  CI (99.9%): [629.000, 629.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30:·gc.time":
+  300.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (9.000, 30.000, 43.000), stdev = 14.095
+  CI (99.9%): [300.000, 300.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30_multibyte
+
+# Run progress: 33.33% complete, ETA 00:14:22
+# Fork: 1 of 2
+# Warmup Iteration   1: 557.794 ops/s
+# Warmup Iteration   2: 742.654 ops/s
+# Warmup Iteration   3: 798.087 ops/s
+# Warmup Iteration   4: 773.907 ops/s
+# Warmup Iteration   5: 792.963 ops/s
+Iteration   1: 792.185 ops/s
+                 ·gc.alloc.rate:                   488.640 MB/sec
+                 ·gc.alloc.rate.norm:              712638.873 B/op
+                 ·gc.churn.PS_Eden_Space:          484.821 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     707068.515 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.091 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 132.178 B/op
+                 ·gc.count:                        19.000 counts
+                 ·gc.time:                         9.000 ms
+
+Iteration   2: 793.085 ops/s
+                 ·gc.alloc.rate:                   488.255 MB/sec
+                 ·gc.alloc.rate.norm:              710928.817 B/op
+                 ·gc.churn.PS_Eden_Space:          489.141 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     712218.749 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.221 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 322.170 B/op
+                 ·gc.count:                        41.000 counts
+                 ·gc.time:                         20.000 ms
+
+Iteration   3: 783.913 ops/s
+                 ·gc.alloc.rate:                   483.074 MB/sec
+                 ·gc.alloc.rate.norm:              710920.118 B/op
+                 ·gc.churn.PS_Eden_Space:          485.584 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     714613.317 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.352 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 517.366 B/op
+                 ·gc.count:                        82.000 counts
+                 ·gc.time:                         40.000 ms
+
+Iteration   4: 809.721 ops/s
+                 ·gc.alloc.rate:                   499.010 MB/sec
+                 ·gc.alloc.rate.norm:              710920.107 B/op
+                 ·gc.churn.PS_Eden_Space:          501.165 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     713989.708 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.369 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 525.548 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         41.000 ms
+
+Iteration   5: 788.686 ops/s
+                 ·gc.alloc.rate:                   485.872 MB/sec
+                 ·gc.alloc.rate.norm:              710920.118 B/op
+                 ·gc.churn.PS_Eden_Space:          492.793 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     721047.842 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.428 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 626.850 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         42.000 ms
+
+
+# Run progress: 36.11% complete, ETA 00:13:46
+# Fork: 2 of 2
+# Warmup Iteration   1: 556.505 ops/s
+# Warmup Iteration   2: 718.737 ops/s
+# Warmup Iteration   3: 754.710 ops/s
+# Warmup Iteration   4: 777.039 ops/s
+# Warmup Iteration   5: 776.980 ops/s
+Iteration   1: 777.488 ops/s
+                 ·gc.alloc.rate:                   480.367 MB/sec
+                 ·gc.alloc.rate.norm:              712686.425 B/op
+                 ·gc.churn.PS_Eden_Space:          502.282 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     745199.988 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.096 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 143.141 B/op
+                 ·gc.count:                        19.000 counts
+                 ·gc.time:                         9.000 ms
+
+Iteration   2: 784.084 ops/s
+                 ·gc.alloc.rate:                   484.139 MB/sec
+                 ·gc.alloc.rate.norm:              712553.653 B/op
+                 ·gc.churn.PS_Eden_Space:          483.944 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     712265.967 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.204 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 300.644 B/op
+                 ·gc.count:                        39.000 counts
+                 ·gc.time:                         20.000 ms
+
+Iteration   3: 778.018 ops/s
+                 ·gc.alloc.rate:                   481.610 MB/sec
+                 ·gc.alloc.rate.norm:              714520.111 B/op
+                 ·gc.churn.PS_Eden_Space:          487.917 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     723876.558 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.414 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 614.494 B/op
+                 ·gc.count:                        81.000 counts
+                 ·gc.time:                         37.000 ms
+
+Iteration   4: 786.826 ops/s
+                 ·gc.alloc.rate:                   486.802 MB/sec
+                 ·gc.alloc.rate.norm:              714520.110 B/op
+                 ·gc.churn.PS_Eden_Space:          486.793 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     714506.936 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.576 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 844.850 B/op
+                 ·gc.count:                        88.000 counts
+                 ·gc.time:                         42.000 ms
+
+Iteration   5: 785.635 ops/s
+                 ·gc.alloc.rate:                   486.510 MB/sec
+                 ·gc.alloc.rate.norm:              714520.110 B/op
+                 ·gc.churn.PS_Eden_Space:          486.494 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     714496.411 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.411 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 604.236 B/op
+                 ·gc.count:                        81.000 counts
+                 ·gc.time:                         41.000 ms
+
+
+
+Result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30_multibyte":
+  787.964 ±(99.9%) 13.937 ops/s [Average]
+  (min, avg, max) = (777.488, 787.964, 809.721), stdev = 9.218
+  CI (99.9%): [774.027, 801.900] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.alloc.rate":
+  486.428 ±(99.9%) 7.863 MB/sec [Average]
+  (min, avg, max) = (480.367, 486.428, 499.010), stdev = 5.201
+  CI (99.9%): [478.565, 494.291] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.alloc.rate.norm":
+  712512.844 ±(99.9%) 2377.381 B/op [Average]
+  (min, avg, max) = (710920.107, 712512.844, 714520.111), stdev = 1572.491
+  CI (99.9%): [710135.463, 714890.226] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Eden_Space":
+  490.093 ±(99.9%) 10.002 MB/sec [Average]
+  (min, avg, max) = (483.944, 490.093, 502.282), stdev = 6.615
+  CI (99.9%): [480.092, 500.095] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Eden_Space.norm":
+  717928.399 ±(99.9%) 16106.302 B/op [Average]
+  (min, avg, max) = (707068.515, 717928.399, 745199.988), stdev = 10653.322
+  CI (99.9%): [701822.097, 734034.701] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space":
+  0.316 ±(99.9%) 0.238 MB/sec [Average]
+  (min, avg, max) = (0.091, 0.316, 0.576), stdev = 0.158
+  CI (99.9%): [0.078, 0.554] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space.norm":
+  463.148 ±(99.9%) 349.282 B/op [Average]
+  (min, avg, max) = (132.178, 463.148, 844.850), stdev = 231.028
+  CI (99.9%): [113.866, 812.430] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.count":
+  628.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (19.000, 62.800, 89.000), stdev = 29.660
+  CI (99.9%): [628.000, 628.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.time":
+  301.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (9.000, 30.100, 42.000), stdev = 13.988
+  CI (99.9%): [301.000, 301.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessagePackerBenchmark.encodeString100_10
+
+# Run progress: 38.89% complete, ETA 00:13:10
+# Fork: 1 of 2
+# Warmup Iteration   1: 27274.380 ops/s
+# Warmup Iteration   2: 51617.871 ops/s
+# Warmup Iteration   3: 54074.310 ops/s
+# Warmup Iteration   4: 61027.589 ops/s
+# Warmup Iteration   5: 57554.385 ops/s
+Iteration   1: 60178.177 ops/s
+                 ·gc.alloc.rate:                   912.744 MB/sec
+                 ·gc.alloc.rate.norm:              17504.002 B/op
+                 ·gc.churn.PS_Eden_Space:          917.047 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     17586.534 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.034 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.653 B/op
+                 ·gc.count:                        19.000 counts
+                 ·gc.time:                         11.000 ms
+
+Iteration   2: 58898.730 ops/s
+                 ·gc.alloc.rate:                   893.147 MB/sec
+                 ·gc.alloc.rate.norm:              17504.001 B/op
+                 ·gc.churn.PS_Eden_Space:          902.832 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     17693.815 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.119 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.335 B/op
+                 ·gc.count:                        57.000 counts
+                 ·gc.time:                         28.000 ms
+
+Iteration   3: 59599.238 ops/s
+                 ·gc.alloc.rate:                   903.694 MB/sec
+                 ·gc.alloc.rate.norm:              17504.002 B/op
+                 ·gc.churn.PS_Eden_Space:          907.073 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     17569.438 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.165 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.186 B/op
+                 ·gc.count:                        93.000 counts
+                 ·gc.time:                         46.000 ms
+
+Iteration   4: 59036.374 ops/s
+                 ·gc.alloc.rate:                   895.292 MB/sec
+                 ·gc.alloc.rate.norm:              17504.001 B/op
+                 ·gc.churn.PS_Eden_Space:          892.331 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     17446.098 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.327 B/op
+                 ·gc.count:                        104.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 59430.830 ops/s
+                 ·gc.alloc.rate:                   901.064 MB/sec
+                 ·gc.alloc.rate.norm:              17504.001 B/op
+                 ·gc.churn.PS_Eden_Space:          897.982 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     17444.116 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.153 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.976 B/op
+                 ·gc.count:                        99.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+# Run progress: 41.67% complete, ETA 00:12:34
+# Fork: 2 of 2
+# Warmup Iteration   1: 31319.295 ops/s
+# Warmup Iteration   2: 52658.182 ops/s
+# Warmup Iteration   3: 61717.540 ops/s
+# Warmup Iteration   4: 62243.493 ops/s
+# Warmup Iteration   5: 62807.588 ops/s
+Iteration   1: 62836.567 ops/s
+                 ·gc.alloc.rate:                   951.814 MB/sec
+                 ·gc.alloc.rate.norm:              17488.001 B/op
+                 ·gc.churn.PS_Eden_Space:          988.085 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     18154.409 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.034 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.625 B/op
+                 ·gc.count:                        20.000 counts
+                 ·gc.time:                         9.000 ms
+
+Iteration   2: 62759.248 ops/s
+                 ·gc.alloc.rate:                   950.741 MB/sec
+                 ·gc.alloc.rate.norm:              17488.001 B/op
+                 ·gc.churn.PS_Eden_Space:          968.062 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     17806.600 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.130 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.400 B/op
+                 ·gc.count:                        64.000 counts
+                 ·gc.time:                         31.000 ms
+
+Iteration   3: 62485.405 ops/s
+                 ·gc.alloc.rate:                   947.291 MB/sec
+                 ·gc.alloc.rate.norm:              17488.001 B/op
+                 ·gc.churn.PS_Eden_Space:          946.873 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     17480.284 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.176 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.248 B/op
+                 ·gc.count:                        97.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   4: 58813.569 ops/s
+                 ·gc.alloc.rate:                   891.584 MB/sec
+                 ·gc.alloc.rate.norm:              17488.001 B/op
+                 ·gc.churn.PS_Eden_Space:          892.702 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     17509.923 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.339 B/op
+                 ·gc.count:                        98.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 62257.109 ops/s
+                 ·gc.alloc.rate:                   943.458 MB/sec
+                 ·gc.alloc.rate.norm:              17488.001 B/op
+                 ·gc.churn.PS_Eden_Space:          941.375 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     17449.390 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.114 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.104 B/op
+                 ·gc.count:                        93.000 counts
+                 ·gc.time:                         45.000 ms
+
+
+
+Result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_10":
+  60629.525 ±(99.9%) 2620.244 ops/s [Average]
+  (min, avg, max) = (58813.569, 60629.525, 62836.567), stdev = 1733.129
+  CI (99.9%): [58009.281, 63249.769] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_10:·gc.alloc.rate":
+  919.083 ±(99.9%) 39.230 MB/sec [Average]
+  (min, avg, max) = (891.584, 919.083, 951.814), stdev = 25.949
+  CI (99.9%): [879.853, 958.314] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_10:·gc.alloc.rate.norm":
+  17496.001 ±(99.9%) 12.749 B/op [Average]
+  (min, avg, max) = (17488.001, 17496.001, 17504.002), stdev = 8.433
+  CI (99.9%): [17483.252, 17508.751] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Eden_Space":
+  925.436 ±(99.9%) 51.134 MB/sec [Average]
+  (min, avg, max) = (892.331, 925.436, 988.085), stdev = 33.822
+  CI (99.9%): [874.302, 976.570] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Eden_Space.norm":
+  17614.061 ±(99.9%) 338.477 B/op [Average]
+  (min, avg, max) = (17444.116, 17614.061, 18154.409), stdev = 223.882
+  CI (99.9%): [17275.584, 17952.538] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Survivor_Space":
+  0.127 ±(99.9%) 0.081 MB/sec [Average]
+  (min, avg, max) = (0.034, 0.127, 0.176), stdev = 0.053
+  CI (99.9%): [0.046, 0.207] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Survivor_Space.norm":
+  2.419 ±(99.9%) 1.570 B/op [Average]
+  (min, avg, max) = (0.625, 2.419, 3.339), stdev = 1.038
+  CI (99.9%): [0.850, 3.989] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_10:·gc.count":
+  744.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (19.000, 74.400, 104.000), stdev = 32.796
+  CI (99.9%): [744.000, 744.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_10:·gc.time":
+  360.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (9.000, 36.000, 48.000), stdev = 15.470
+  CI (99.9%): [360.000, 360.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessagePackerBenchmark.encodeString100_30
+
+# Run progress: 44.44% complete, ETA 00:11:58
+# Fork: 1 of 2
+# Warmup Iteration   1: 9212.977 ops/s
+# Warmup Iteration   2: 17843.668 ops/s
+# Warmup Iteration   3: 17315.429 ops/s
+# Warmup Iteration   4: 17659.013 ops/s
+# Warmup Iteration   5: 19957.522 ops/s
+Iteration   1: 19707.644 ops/s
+                 ·gc.alloc.rate:                   754.211 MB/sec
+                 ·gc.alloc.rate.norm:              44149.586 B/op
+                 ·gc.churn.PS_Eden_Space:          759.042 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     44432.359 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.023 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.330 B/op
+                 ·gc.count:                        13.000 counts
+                 ·gc.time:                         7.000 ms
+
+Iteration   2: 19623.447 ops/s
+                 ·gc.alloc.rate:                   750.401 MB/sec
+                 ·gc.alloc.rate.norm:              44136.005 B/op
+                 ·gc.churn.PS_Eden_Space:          762.347 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     44838.594 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.074 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 4.338 B/op
+                 ·gc.count:                        27.000 counts
+                 ·gc.time:                         14.000 ms
+
+Iteration   3: 19999.506 ops/s
+                 ·gc.alloc.rate:                   764.675 MB/sec
+                 ·gc.alloc.rate.norm:              44136.004 B/op
+                 ·gc.churn.PS_Eden_Space:          774.828 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     44722.042 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.148 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 8.515 B/op
+                 ·gc.count:                        81.000 counts
+                 ·gc.time:                         39.000 ms
+
+Iteration   4: 20325.656 ops/s
+                 ·gc.alloc.rate:                   777.103 MB/sec
+                 ·gc.alloc.rate.norm:              44136.004 B/op
+                 ·gc.churn.PS_Eden_Space:          774.109 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     43965.991 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.176 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 9.986 B/op
+                 ·gc.count:                        101.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   5: 20131.015 ops/s
+                 ·gc.alloc.rate:                   770.184 MB/sec
+                 ·gc.alloc.rate.norm:              44136.005 B/op
+                 ·gc.churn.PS_Eden_Space:          773.142 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     44305.515 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.142 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 8.136 B/op
+                 ·gc.count:                        81.000 counts
+                 ·gc.time:                         41.000 ms
+
+
+# Run progress: 47.22% complete, ETA 00:11:22
+# Fork: 2 of 2
+# Warmup Iteration   1: 9719.154 ops/s
+# Warmup Iteration   2: 16584.344 ops/s
+# Warmup Iteration   3: 19561.711 ops/s
+# Warmup Iteration   4: 20154.505 ops/s
+# Warmup Iteration   5: 19957.435 ops/s
+Iteration   1: 19678.894 ops/s
+                 ·gc.alloc.rate:                   692.499 MB/sec
+                 ·gc.alloc.rate.norm:              40605.965 B/op
+                 ·gc.churn.PS_Eden_Space:          712.499 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     41778.717 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.068 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.996 B/op
+                 ·gc.count:                        41.000 counts
+                 ·gc.time:                         19.000 ms
+
+Iteration   2: 19292.872 ops/s
+                 ·gc.alloc.rate:                   678.846 MB/sec
+                 ·gc.alloc.rate.norm:              40600.005 B/op
+                 ·gc.churn.PS_Eden_Space:          678.576 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     40583.837 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.165 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 9.843 B/op
+                 ·gc.count:                        94.000 counts
+                 ·gc.time:                         45.000 ms
+
+Iteration   3: 19370.162 ops/s
+                 ·gc.alloc.rate:                   681.428 MB/sec
+                 ·gc.alloc.rate.norm:              40600.004 B/op
+                 ·gc.churn.PS_Eden_Space:          675.469 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     40244.943 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.187 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 11.158 B/op
+                 ·gc.count:                        94.000 counts
+                 ·gc.time:                         46.000 ms
+
+Iteration   4: 19489.288 ops/s
+                 ·gc.alloc.rate:                   685.590 MB/sec
+                 ·gc.alloc.rate.norm:              40600.005 B/op
+                 ·gc.churn.PS_Eden_Space:          691.263 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     40935.980 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.136 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 8.062 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         42.000 ms
+
+Iteration   5: 19927.550 ops/s
+                 ·gc.alloc.rate:                   701.003 MB/sec
+                 ·gc.alloc.rate.norm:              40600.004 B/op
+                 ·gc.churn.PS_Eden_Space:          701.889 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     40651.324 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.159 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 9.200 B/op
+                 ·gc.count:                        91.000 counts
+                 ·gc.time:                         45.000 ms
+
+
+
+Result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_30":
+  19754.603 ±(99.9%) 507.517 ops/s [Average]
+  (min, avg, max) = (19292.872, 19754.603, 20325.656), stdev = 335.691
+  CI (99.9%): [19247.086, 20262.121] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_30:·gc.alloc.rate":
+  725.594 ±(99.9%) 61.802 MB/sec [Average]
+  (min, avg, max) = (678.846, 725.594, 777.103), stdev = 40.878
+  CI (99.9%): [663.792, 787.396] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_30:·gc.alloc.rate.norm":
+  42369.959 ±(99.9%) 2818.773 B/op [Average]
+  (min, avg, max) = (40600.004, 42369.959, 44149.586), stdev = 1864.444
+  CI (99.9%): [39551.185, 45188.732] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Eden_Space":
+  730.316 ±(99.9%) 63.586 MB/sec [Average]
+  (min, avg, max) = (675.469, 730.316, 774.828), stdev = 42.058
+  CI (99.9%): [666.730, 793.903] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Eden_Space.norm":
+  42645.930 ±(99.9%) 2959.086 B/op [Average]
+  (min, avg, max) = (40244.943, 42645.930, 44838.594), stdev = 1957.252
+  CI (99.9%): [39686.844, 45605.017] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Survivor_Space":
+  0.128 ±(99.9%) 0.082 MB/sec [Average]
+  (min, avg, max) = (0.023, 0.128, 0.187), stdev = 0.054
+  CI (99.9%): [0.046, 0.209] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Survivor_Space.norm":
+  7.456 ±(99.9%) 4.781 B/op [Average]
+  (min, avg, max) = (1.330, 7.456, 11.158), stdev = 3.163
+  CI (99.9%): [2.675, 12.238] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_30:·gc.count":
+  712.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (13.000, 71.200, 101.000), stdev = 31.766
+  CI (99.9%): [712.000, 712.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessagePackerBenchmark.encodeString100_30:·gc.time":
+  345.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (7.000, 34.500, 47.000), stdev = 15.072
+  CI (99.9%): [345.000, 345.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessageUnpackerBenchmark.decodeCirceAST
+
+# Run progress: 50.00% complete, ETA 00:10:46
+# Fork: 1 of 2
+# Warmup Iteration   1: 16049.152 ops/s
+# Warmup Iteration   2: 37984.756 ops/s
+# Warmup Iteration   3: 41652.933 ops/s
+# Warmup Iteration   4: 46041.655 ops/s
+# Warmup Iteration   5: 46384.317 ops/s
+Iteration   1: 46483.321 ops/s
+                 ·gc.alloc.rate:                   2015.432 MB/sec
+                 ·gc.alloc.rate.norm:              50056.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2021.350 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     50202.991 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.034 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.845 B/op
+                 ·gc.count:                        44.000 counts
+                 ·gc.time:                         24.000 ms
+
+Iteration   2: 46093.243 ops/s
+                 ·gc.alloc.rate:                   1999.761 MB/sec
+                 ·gc.alloc.rate.norm:              50056.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1990.180 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     49816.178 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.182 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 4.545 B/op
+                 ·gc.count:                        92.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   3: 46566.875 ops/s
+                 ·gc.alloc.rate:                   2020.258 MB/sec
+                 ·gc.alloc.rate.norm:              50056.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2018.879 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     50021.849 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.136 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.374 B/op
+                 ·gc.count:                        92.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   4: 46229.452 ops/s
+                 ·gc.alloc.rate:                   2005.040 MB/sec
+                 ·gc.alloc.rate.norm:              50056.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2003.108 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     50007.761 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.131 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.259 B/op
+                 ·gc.count:                        94.000 counts
+                 ·gc.time:                         49.000 ms
+
+Iteration   5: 46207.204 ops/s
+                 ·gc.alloc.rate:                   2003.838 MB/sec
+                 ·gc.alloc.rate.norm:              50056.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2016.906 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     50382.438 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 4.251 B/op
+                 ·gc.count:                        91.000 counts
+                 ·gc.time:                         48.000 ms
+
+
+# Run progress: 52.78% complete, ETA 00:10:10
+# Fork: 2 of 2
+# Warmup Iteration   1: 17143.752 ops/s
+# Warmup Iteration   2: 39425.759 ops/s
+# Warmup Iteration   3: 38797.541 ops/s
+# Warmup Iteration   4: 37812.755 ops/s
+# Warmup Iteration   5: 48498.197 ops/s
+Iteration   1: 49159.649 ops/s
+                 ·gc.alloc.rate:                   2132.491 MB/sec
+                 ·gc.alloc.rate.norm:              50056.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2156.231 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     50613.264 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.028 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.666 B/op
+                 ·gc.count:                        15.000 counts
+                 ·gc.time:                         9.000 ms
+
+Iteration   2: 49573.345 ops/s
+                 ·gc.alloc.rate:                   2150.946 MB/sec
+                 ·gc.alloc.rate.norm:              50056.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2155.154 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     50153.937 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.085 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.982 B/op
+                 ·gc.count:                        50.000 counts
+                 ·gc.time:                         28.000 ms
+
+Iteration   3: 49388.030 ops/s
+                 ·gc.alloc.rate:                   2142.232 MB/sec
+                 ·gc.alloc.rate.norm:              50056.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2146.239 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     50149.619 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.136 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.183 B/op
+                 ·gc.count:                        93.000 counts
+                 ·gc.time:                         49.000 ms
+
+Iteration   4: 49072.993 ops/s
+                 ·gc.alloc.rate:                   2127.684 MB/sec
+                 ·gc.alloc.rate.norm:              50056.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2118.168 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     49832.131 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.159 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.737 B/op
+                 ·gc.count:                        83.000 counts
+                 ·gc.time:                         45.000 ms
+
+Iteration   5: 49381.288 ops/s
+                 ·gc.alloc.rate:                   2141.538 MB/sec
+                 ·gc.alloc.rate.norm:              50056.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2154.443 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     50357.647 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.136 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.184 B/op
+                 ·gc.count:                        88.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+
+Result "fluflu.msgpack.MessageUnpackerBenchmark.decodeCirceAST":
+  47815.540 ±(99.9%) 2406.587 ops/s [Average]
+  (min, avg, max) = (46093.243, 47815.540, 49573.345), stdev = 1591.808
+  CI (99.9%): [45408.953, 50222.127] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeCirceAST:·gc.alloc.rate":
+  2073.922 ±(99.9%) 104.439 MB/sec [Average]
+  (min, avg, max) = (1999.761, 2073.922, 2150.946), stdev = 69.080
+  CI (99.9%): [1969.482, 2178.361] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeCirceAST:·gc.alloc.rate.norm":
+  50056.002 ±(99.9%) 0.001 B/op [Average]
+  (min, avg, max) = (50056.002, 50056.002, 50056.002), stdev = 0.001
+  CI (99.9%): [50056.002, 50056.002] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Eden_Space":
+  2078.066 ±(99.9%) 110.347 MB/sec [Average]
+  (min, avg, max) = (1990.180, 2078.066, 2156.231), stdev = 72.987
+  CI (99.9%): [1967.719, 2188.412] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Eden_Space.norm":
+  50153.781 ±(99.9%) 378.324 B/op [Average]
+  (min, avg, max) = (49816.178, 50153.781, 50613.264), stdev = 250.238
+  CI (99.9%): [49775.457, 50532.106] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Survivor_Space":
+  0.120 ±(99.9%) 0.081 MB/sec [Average]
+  (min, avg, max) = (0.028, 0.120, 0.182), stdev = 0.053
+  CI (99.9%): [0.039, 0.201] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Survivor_Space.norm":
+  2.903 ±(99.9%) 2.003 B/op [Average]
+  (min, avg, max) = (0.666, 2.903, 4.545), stdev = 1.325
+  CI (99.9%): [0.899, 4.906] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeCirceAST:·gc.count":
+  742.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (15.000, 74.200, 94.000), stdev = 27.752
+  CI (99.9%): [742.000, 742.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeCirceAST:·gc.time":
+  395.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (9.000, 39.500, 49.000), stdev = 14.089
+  CI (99.9%): [395.000, 395.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessageUnpackerBenchmark.decodeInt10
+
+# Run progress: 55.56% complete, ETA 00:09:34
+# Fork: 1 of 2
+# Warmup Iteration   1: 32493.345 ops/s
+# Warmup Iteration   2: 140572.779 ops/s
+# Warmup Iteration   3: 160137.587 ops/s
+# Warmup Iteration   4: 182354.534 ops/s
+# Warmup Iteration   5: 188742.696 ops/s
+Iteration   1: 179834.099 ops/s
+                 ·gc.alloc.rate:                   1655.732 MB/sec
+                 ·gc.alloc.rate.norm:              10624.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1668.005 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10702.753 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.040 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.255 B/op
+                 ·gc.count:                        25.000 counts
+                 ·gc.time:                         17.000 ms
+
+Iteration   2: 179818.796 ops/s
+                 ·gc.alloc.rate:                   1655.044 MB/sec
+                 ·gc.alloc.rate.norm:              10624.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1670.788 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10725.059 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.147 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.947 B/op
+                 ·gc.count:                        81.000 counts
+                 ·gc.time:                         44.000 ms
+
+Iteration   3: 178941.465 ops/s
+                 ·gc.alloc.rate:                   1647.780 MB/sec
+                 ·gc.alloc.rate.norm:              10624.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1649.993 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10638.269 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.131 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.841 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   4: 179234.052 ops/s
+                 ·gc.alloc.rate:                   1649.750 MB/sec
+                 ·gc.alloc.rate.norm:              10624.000 B/op
+                 ·gc.churn.PS_Eden_Space:          1649.972 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10625.429 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.199 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.279 B/op
+                 ·gc.count:                        91.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 184252.910 ops/s
+                 ·gc.alloc.rate:                   1697.036 MB/sec
+                 ·gc.alloc.rate.norm:              10624.000 B/op
+                 ·gc.churn.PS_Eden_Space:          1680.666 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10521.518 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.125 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.782 B/op
+                 ·gc.count:                        91.000 counts
+                 ·gc.time:                         48.000 ms
+
+
+# Run progress: 58.33% complete, ETA 00:08:58
+# Fork: 2 of 2
+# Warmup Iteration   1: 36984.346 ops/s
+# Warmup Iteration   2: 148064.118 ops/s
+# Warmup Iteration   3: 161074.489 ops/s
+# Warmup Iteration   4: 197690.654 ops/s
+# Warmup Iteration   5: 189980.835 ops/s
+Iteration   1: 191408.327 ops/s
+                 ·gc.alloc.rate:                   1800.918 MB/sec
+                 ·gc.alloc.rate.norm:              10864.000 B/op
+                 ·gc.churn.PS_Eden_Space:          1792.572 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10813.655 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.051 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.308 B/op
+                 ·gc.count:                        31.000 counts
+                 ·gc.time:                         21.000 ms
+
+Iteration   2: 193484.355 ops/s
+                 ·gc.alloc.rate:                   1821.654 MB/sec
+                 ·gc.alloc.rate.norm:              10864.000 B/op
+                 ·gc.churn.PS_Eden_Space:          1842.985 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10991.212 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.204 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.219 B/op
+                 ·gc.count:                        85.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   3: 189298.188 ops/s
+                 ·gc.alloc.rate:                   1780.569 MB/sec
+                 ·gc.alloc.rate.norm:              10864.000 B/op
+                 ·gc.churn.PS_Eden_Space:          1767.810 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10786.155 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.108 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.657 B/op
+                 ·gc.count:                        85.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   4: 188617.443 ops/s
+                 ·gc.alloc.rate:                   1774.157 MB/sec
+                 ·gc.alloc.rate.norm:              10864.000 B/op
+                 ·gc.churn.PS_Eden_Space:          1790.451 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10963.776 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.041 B/op
+                 ·gc.count:                        88.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   5: 190638.626 ops/s
+                 ·gc.alloc.rate:                   1792.199 MB/sec
+                 ·gc.alloc.rate.norm:              10864.000 B/op
+                 ·gc.churn.PS_Eden_Space:          1782.411 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     10804.670 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.031 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         48.000 ms
+
+
+
+Result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt10":
+  185552.826 ±(99.9%) 8690.670 ops/s [Average]
+  (min, avg, max) = (178941.465, 185552.826, 193484.355), stdev = 5748.340
+  CI (99.9%): [176862.156, 194243.496] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt10:·gc.alloc.rate":
+  1727.484 ±(99.9%) 109.444 MB/sec [Average]
+  (min, avg, max) = (1647.780, 1727.484, 1821.654), stdev = 72.390
+  CI (99.9%): [1618.040, 1836.928] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt10:·gc.alloc.rate.norm":
+  10744.000 ±(99.9%) 191.236 B/op [Average]
+  (min, avg, max) = (10624.000, 10744.000, 10864.000), stdev = 126.491
+  CI (99.9%): [10552.764, 10935.237] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Eden_Space":
+  1729.565 ±(99.9%) 109.369 MB/sec [Average]
+  (min, avg, max) = (1649.972, 1729.565, 1842.985), stdev = 72.341
+  CI (99.9%): [1620.196, 1838.934] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Eden_Space.norm":
+  10757.250 ±(99.9%) 222.406 B/op [Average]
+  (min, avg, max) = (10521.518, 10757.250, 10991.212), stdev = 147.108
+  CI (99.9%): [10534.844, 10979.655] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Survivor_Space":
+  0.134 ±(99.9%) 0.085 MB/sec [Average]
+  (min, avg, max) = (0.040, 0.134, 0.204), stdev = 0.056
+  CI (99.9%): [0.049, 0.219] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Survivor_Space.norm":
+  0.836 ±(99.9%) 0.525 B/op [Average]
+  (min, avg, max) = (0.255, 0.836, 1.279), stdev = 0.348
+  CI (99.9%): [0.311, 1.361] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt10:·gc.count":
+  755.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (25.000, 75.500, 91.000), stdev = 25.260
+  CI (99.9%): [755.000, 755.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt10:·gc.time":
+  415.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (17.000, 41.500, 48.000), stdev = 11.956
+  CI (99.9%): [415.000, 415.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessageUnpackerBenchmark.decodeInt30
+
+# Run progress: 61.11% complete, ETA 00:08:22
+# Fork: 1 of 2
+# Warmup Iteration   1: 13132.719 ops/s
+# Warmup Iteration   2: 41528.543 ops/s
+# Warmup Iteration   3: 46392.716 ops/s
+# Warmup Iteration   4: 54773.842 ops/s
+# Warmup Iteration   5: 55657.014 ops/s
+Iteration   1: 54960.215 ops/s
+                 ·gc.alloc.rate:                   1874.591 MB/sec
+                 ·gc.alloc.rate.norm:              39392.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1899.508 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     39915.608 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.028 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.595 B/op
+                 ·gc.count:                        32.000 counts
+                 ·gc.time:                         18.000 ms
+
+Iteration   2: 54892.805 ops/s
+                 ·gc.alloc.rate:                   1873.398 MB/sec
+                 ·gc.alloc.rate.norm:              39392.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1867.937 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     39277.190 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.136 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.862 B/op
+                 ·gc.count:                        86.000 counts
+                 ·gc.time:                         45.000 ms
+
+Iteration   3: 54772.387 ops/s
+                 ·gc.alloc.rate:                   1868.217 MB/sec
+                 ·gc.alloc.rate.norm:              39392.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1852.200 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     39054.278 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.164 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.466 B/op
+                 ·gc.count:                        94.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   4: 54706.460 ops/s
+                 ·gc.alloc.rate:                   1865.860 MB/sec
+                 ·gc.alloc.rate.norm:              39392.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1867.009 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     39416.248 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.102 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.154 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   5: 54001.615 ops/s
+                 ·gc.alloc.rate:                   1841.048 MB/sec
+                 ·gc.alloc.rate.norm:              39392.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1853.515 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     39658.752 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.147 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.153 B/op
+                 ·gc.count:                        82.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+# Run progress: 63.89% complete, ETA 00:07:46
+# Fork: 2 of 2
+# Warmup Iteration   1: 15599.826 ops/s
+# Warmup Iteration   2: 43066.941 ops/s
+# Warmup Iteration   3: 47795.856 ops/s
+# Warmup Iteration   4: 54155.520 ops/s
+# Warmup Iteration   5: 56128.908 ops/s
+Iteration   1: 55619.726 ops/s
+                 ·gc.alloc.rate:                   1896.715 MB/sec
+                 ·gc.alloc.rate.norm:              39392.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1955.363 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     40610.028 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.062 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.294 B/op
+                 ·gc.count:                        34.000 counts
+                 ·gc.time:                         19.000 ms
+
+Iteration   2: 55571.711 ops/s
+                 ·gc.alloc.rate:                   1895.263 MB/sec
+                 ·gc.alloc.rate.norm:              39392.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1891.792 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     39319.855 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.159 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.302 B/op
+                 ·gc.count:                        91.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   3: 55271.194 ops/s
+                 ·gc.alloc.rate:                   1885.024 MB/sec
+                 ·gc.alloc.rate.norm:              39392.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1892.826 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     39555.058 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.153 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.200 B/op
+                 ·gc.count:                        94.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   4: 54405.415 ops/s
+                 ·gc.alloc.rate:                   1856.749 MB/sec
+                 ·gc.alloc.rate.norm:              39392.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1852.479 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     39301.395 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.142 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.007 B/op
+                 ·gc.count:                        87.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 52035.021 ops/s
+                 ·gc.alloc.rate:                   1774.972 MB/sec
+                 ·gc.alloc.rate.norm:              39392.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1784.498 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     39603.404 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.153 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.394 B/op
+                 ·gc.count:                        85.000 counts
+                 ·gc.time:                         48.000 ms
+
+
+
+Result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt30":
+  54623.655 ±(99.9%) 1566.356 ops/s [Average]
+  (min, avg, max) = (52035.021, 54623.655, 55619.726), stdev = 1036.048
+  CI (99.9%): [53057.299, 56190.011] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt30:·gc.alloc.rate":
+  1863.184 ±(99.9%) 53.357 MB/sec [Average]
+  (min, avg, max) = (1774.972, 1863.184, 1896.715), stdev = 35.293
+  CI (99.9%): [1809.826, 1916.541] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt30:·gc.alloc.rate.norm":
+  39392.002 ±(99.9%) 0.001 B/op [Average]
+  (min, avg, max) = (39392.002, 39392.002, 39392.002), stdev = 0.001
+  CI (99.9%): [39392.002, 39392.002] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Eden_Space":
+  1871.713 ±(99.9%) 66.368 MB/sec [Average]
+  (min, avg, max) = (1784.498, 1871.713, 1955.363), stdev = 43.898
+  CI (99.9%): [1805.345, 1938.081] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Eden_Space.norm":
+  39571.182 ±(99.9%) 660.999 B/op [Average]
+  (min, avg, max) = (39054.278, 39571.182, 40610.028), stdev = 437.210
+  CI (99.9%): [38910.182, 40232.181] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Survivor_Space":
+  0.125 ±(99.9%) 0.069 MB/sec [Average]
+  (min, avg, max) = (0.028, 0.125, 0.164), stdev = 0.046
+  CI (99.9%): [0.055, 0.194] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Survivor_Space.norm":
+  2.643 ±(99.9%) 1.485 B/op [Average]
+  (min, avg, max) = (0.595, 2.643, 3.466), stdev = 0.982
+  CI (99.9%): [1.158, 4.127] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt30:·gc.count":
+  774.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (32.000, 77.400, 94.000), stdev = 23.712
+  CI (99.9%): [774.000, 774.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeInt30:·gc.time":
+  416.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (18.000, 41.600, 48.000), stdev = 12.213
+  CI (99.9%): [416.000, 416.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessageUnpackerBenchmark.decodeLong10
+
+# Run progress: 66.67% complete, ETA 00:07:10
+# Fork: 1 of 2
+# Warmup Iteration   1: 8917.854 ops/s
+# Warmup Iteration   2: 30526.711 ops/s
+# Warmup Iteration   3: 47109.706 ops/s
+# Warmup Iteration   4: 65869.308 ops/s
+# Warmup Iteration   5: 65597.778 ops/s
+Iteration   1: 65307.972 ops/s
+                 ·gc.alloc.rate:                   1929.655 MB/sec
+                 ·gc.alloc.rate.norm:              34136.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1955.921 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34600.657 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.040 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.702 B/op
+                 ·gc.count:                        34.000 counts
+                 ·gc.time:                         24.000 ms
+
+Iteration   2: 65157.453 ops/s
+                 ·gc.alloc.rate:                   1926.583 MB/sec
+                 ·gc.alloc.rate.norm:              34136.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1927.680 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34155.444 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.125 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.210 B/op
+                 ·gc.count:                        90.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   3: 63040.979 ops/s
+                 ·gc.alloc.rate:                   1864.161 MB/sec
+                 ·gc.alloc.rate.norm:              34136.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1851.785 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     33909.372 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.102 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.869 B/op
+                 ·gc.count:                        84.000 counts
+                 ·gc.time:                         46.000 ms
+
+Iteration   4: 65038.242 ops/s
+                 ·gc.alloc.rate:                   1921.726 MB/sec
+                 ·gc.alloc.rate.norm:              34136.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1913.832 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     33995.775 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.147 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.616 B/op
+                 ·gc.count:                        85.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 66103.390 ops/s
+                 ·gc.alloc.rate:                   1953.015 MB/sec
+                 ·gc.alloc.rate.norm:              34136.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1969.655 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34426.845 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.147 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.574 B/op
+                 ·gc.count:                        85.000 counts
+                 ·gc.time:                         46.000 ms
+
+
+# Run progress: 69.44% complete, ETA 00:06:35
+# Fork: 2 of 2
+# Warmup Iteration   1: 9911.935 ops/s
+# Warmup Iteration   2: 34219.158 ops/s
+# Warmup Iteration   3: 45721.929 ops/s
+# Warmup Iteration   4: 60668.010 ops/s
+# Warmup Iteration   5: 61216.702 ops/s
+Iteration   1: 61196.752 ops/s
+                 ·gc.alloc.rate:                   1825.566 MB/sec
+                 ·gc.alloc.rate.norm:              34472.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1896.789 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     35816.898 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.034 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.642 B/op
+                 ·gc.count:                        19.000 counts
+                 ·gc.time:                         11.000 ms
+
+Iteration   2: 60761.700 ops/s
+                 ·gc.alloc.rate:                   1813.113 MB/sec
+                 ·gc.alloc.rate.norm:              34472.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1826.174 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34720.318 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.085 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.615 B/op
+                 ·gc.count:                        67.000 counts
+                 ·gc.time:                         36.000 ms
+
+Iteration   3: 60912.654 ops/s
+                 ·gc.alloc.rate:                   1819.127 MB/sec
+                 ·gc.alloc.rate.norm:              34472.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1809.566 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34290.832 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.142 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.685 B/op
+                 ·gc.count:                        91.000 counts
+                 ·gc.time:                         49.000 ms
+
+Iteration   4: 61314.843 ops/s
+                 ·gc.alloc.rate:                   1831.208 MB/sec
+                 ·gc.alloc.rate.norm:              34472.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1833.258 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34510.585 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.147 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.775 B/op
+                 ·gc.count:                        86.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   5: 60870.267 ops/s
+                 ·gc.alloc.rate:                   1816.946 MB/sec
+                 ·gc.alloc.rate.norm:              34472.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1821.171 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     34552.158 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.119 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.259 B/op
+                 ·gc.count:                        87.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+
+Result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong10":
+  62970.425 ±(99.9%) 3333.483 ops/s [Average]
+  (min, avg, max) = (60761.700, 62970.425, 66103.390), stdev = 2204.892
+  CI (99.9%): [59636.943, 66303.908] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong10:·gc.alloc.rate":
+  1870.110 ±(99.9%) 85.046 MB/sec [Average]
+  (min, avg, max) = (1813.113, 1870.110, 1953.015), stdev = 56.253
+  CI (99.9%): [1785.064, 1955.156] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong10:·gc.alloc.rate.norm":
+  34304.001 ±(99.9%) 267.731 B/op [Average]
+  (min, avg, max) = (34136.001, 34304.001, 34472.002), stdev = 177.088
+  CI (99.9%): [34036.270, 34571.733] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Eden_Space":
+  1880.583 ±(99.9%) 89.865 MB/sec [Average]
+  (min, avg, max) = (1809.566, 1880.583, 1969.655), stdev = 59.440
+  CI (99.9%): [1790.718, 1970.448] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Eden_Space.norm":
+  34497.888 ±(99.9%) 807.360 B/op [Average]
+  (min, avg, max) = (33909.372, 34497.888, 35816.898), stdev = 534.019
+  CI (99.9%): [33690.528, 35305.249] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Survivor_Space":
+  0.109 ±(99.9%) 0.065 MB/sec [Average]
+  (min, avg, max) = (0.034, 0.109, 0.147), stdev = 0.043
+  CI (99.9%): [0.043, 0.174] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Survivor_Space.norm":
+  1.995 ±(99.9%) 1.191 B/op [Average]
+  (min, avg, max) = (0.642, 1.995, 2.775), stdev = 0.788
+  CI (99.9%): [0.804, 3.185] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong10:·gc.count":
+  728.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (19.000, 72.800, 91.000), stdev = 25.516
+  CI (99.9%): [728.000, 728.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong10:·gc.time":
+  402.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (11.000, 40.200, 49.000), stdev = 12.874
+  CI (99.9%): [402.000, 402.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessageUnpackerBenchmark.decodeLong30
+
+# Run progress: 72.22% complete, ETA 00:05:59
+# Fork: 1 of 2
+# Warmup Iteration   1: 3452.208 ops/s
+# Warmup Iteration   2: 12105.151 ops/s
+# Warmup Iteration   3: 19757.307 ops/s
+# Warmup Iteration   4: 21420.889 ops/s
+# Warmup Iteration   5: 20080.728 ops/s
+Iteration   1: 20491.993 ops/s
+                 ·gc.alloc.rate:                   1919.298 MB/sec
+                 ·gc.alloc.rate.norm:              108032.039 B/op
+                 ·gc.churn.PS_Eden_Space:          1945.090 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     109483.791 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.113 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 6.386 B/op
+                 ·gc.count:                        80.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   2: 20517.397 ops/s
+                 ·gc.alloc.rate:                   1919.602 MB/sec
+                 ·gc.alloc.rate.norm:              108024.005 B/op
+                 ·gc.churn.PS_Eden_Space:          1930.875 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     108658.400 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.113 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 6.375 B/op
+                 ·gc.count:                        76.000 counts
+                 ·gc.time:                         41.000 ms
+
+Iteration   3: 20463.338 ops/s
+                 ·gc.alloc.rate:                   1914.512 MB/sec
+                 ·gc.alloc.rate.norm:              108024.004 B/op
+                 ·gc.churn.PS_Eden_Space:          1902.065 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     107321.694 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.113 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 6.398 B/op
+                 ·gc.count:                        84.000 counts
+                 ·gc.time:                         46.000 ms
+
+Iteration   4: 20710.615 ops/s
+                 ·gc.alloc.rate:                   1937.188 MB/sec
+                 ·gc.alloc.rate.norm:              108024.004 B/op
+                 ·gc.churn.PS_Eden_Space:          1950.554 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     108769.375 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.113 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 6.319 B/op
+                 ·gc.count:                        91.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 20308.684 ops/s
+                 ·gc.alloc.rate:                   1901.101 MB/sec
+                 ·gc.alloc.rate.norm:              108024.004 B/op
+                 ·gc.churn.PS_Eden_Space:          1891.098 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     107455.586 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.108 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 6.121 B/op
+                 ·gc.count:                        87.000 counts
+                 ·gc.time:                         48.000 ms
+
+
+# Run progress: 75.00% complete, ETA 00:05:23
+# Fork: 2 of 2
+# Warmup Iteration   1: 3125.313 ops/s
+# Warmup Iteration   2: 13615.510 ops/s
+# Warmup Iteration   3: 20290.489 ops/s
+# Warmup Iteration   4: 20272.307 ops/s
+# Warmup Iteration   5: 20197.569 ops/s
+Iteration   1: 20348.648 ops/s
+                 ·gc.alloc.rate:                   1904.247 MB/sec
+                 ·gc.alloc.rate.norm:              108031.881 B/op
+                 ·gc.churn.PS_Eden_Space:          1900.752 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     107833.597 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.102 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 5.788 B/op
+                 ·gc.count:                        79.000 counts
+                 ·gc.time:                         43.000 ms
+
+Iteration   2: 20294.923 ops/s
+                 ·gc.alloc.rate:                   1898.762 MB/sec
+                 ·gc.alloc.rate.norm:              108024.005 B/op
+                 ·gc.churn.PS_Eden_Space:          1903.357 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     108285.452 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.153 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 8.709 B/op
+                 ·gc.count:                        85.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   3: 20427.468 ops/s
+                 ·gc.alloc.rate:                   1910.117 MB/sec
+                 ·gc.alloc.rate.norm:              108024.004 B/op
+                 ·gc.churn.PS_Eden_Space:          1922.127 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     108703.226 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.096 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 5.444 B/op
+                 ·gc.count:                        83.000 counts
+                 ·gc.time:                         45.000 ms
+
+Iteration   4: 20257.798 ops/s
+                 ·gc.alloc.rate:                   1895.148 MB/sec
+                 ·gc.alloc.rate.norm:              108024.004 B/op
+                 ·gc.churn.PS_Eden_Space:          1895.107 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     108021.710 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.148 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 8.410 B/op
+                 ·gc.count:                        88.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 20331.696 ops/s
+                 ·gc.alloc.rate:                   1901.434 MB/sec
+                 ·gc.alloc.rate.norm:              108024.005 B/op
+                 ·gc.churn.PS_Eden_Space:          1894.291 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     107618.203 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.108 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 6.114 B/op
+                 ·gc.count:                        86.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+
+Result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong30":
+  20415.256 ±(99.9%) 206.602 ops/s [Average]
+  (min, avg, max) = (20257.798, 20415.256, 20710.615), stdev = 136.654
+  CI (99.9%): [20208.654, 20621.858] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong30:·gc.alloc.rate":
+  1910.141 ±(99.9%) 19.325 MB/sec [Average]
+  (min, avg, max) = (1895.148, 1910.141, 1937.188), stdev = 12.783
+  CI (99.9%): [1890.815, 1929.466] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong30:·gc.alloc.rate.norm":
+  108025.595 ±(99.9%) 5.072 B/op [Average]
+  (min, avg, max) = (108024.004, 108025.595, 108032.039), stdev = 3.355
+  CI (99.9%): [108020.524, 108030.667] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Eden_Space":
+  1913.532 ±(99.9%) 33.248 MB/sec [Average]
+  (min, avg, max) = (1891.098, 1913.532, 1950.554), stdev = 21.991
+  CI (99.9%): [1880.284, 1946.779] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Eden_Space.norm":
+  108215.103 ±(99.9%) 1041.463 B/op [Average]
+  (min, avg, max) = (107321.694, 108215.103, 109483.791), stdev = 688.863
+  CI (99.9%): [107173.640, 109256.566] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Survivor_Space":
+  0.117 ±(99.9%) 0.028 MB/sec [Average]
+  (min, avg, max) = (0.096, 0.117, 0.153), stdev = 0.019
+  CI (99.9%): [0.089, 0.145] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Survivor_Space.norm":
+  6.606 ±(99.9%) 1.625 B/op [Average]
+  (min, avg, max) = (5.444, 6.606, 8.709), stdev = 1.075
+  CI (99.9%): [4.981, 8.232] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong30:·gc.count":
+  839.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (76.000, 83.900, 91.000), stdev = 4.533
+  CI (99.9%): [839.000, 839.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeLong30:·gc.time":
+  460.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (41.000, 46.000, 48.000), stdev = 2.357
+  CI (99.9%): [460.000, 460.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30
+
+# Run progress: 77.78% complete, ETA 00:04:47
+# Fork: 1 of 2
+# Warmup Iteration   1: 5645.011 ops/s
+# Warmup Iteration   2: 12294.195 ops/s
+# Warmup Iteration   3: 11644.625 ops/s
+# Warmup Iteration   4: 16336.569 ops/s
+# Warmup Iteration   5: 17541.585 ops/s
+Iteration   1: 18071.512 ops/s
+                 ·gc.alloc.rate:                   2938.289 MB/sec
+                 ·gc.alloc.rate.norm:              187828.688 B/op
+                 ·gc.churn.PS_Eden_Space:          3092.997 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     197718.313 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.051 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.263 B/op
+                 ·gc.count:                        33.000 counts
+                 ·gc.time:                         19.000 ms
+
+Iteration   2: 17997.904 ops/s
+                 ·gc.alloc.rate:                   2927.354 MB/sec
+                 ·gc.alloc.rate.norm:              187816.005 B/op
+                 ·gc.churn.PS_Eden_Space:          2918.336 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     187237.407 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.181 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 11.630 B/op
+                 ·gc.count:                        92.000 counts
+                 ·gc.time:                         49.000 ms
+
+Iteration   3: 18207.234 ops/s
+                 ·gc.alloc.rate:                   2961.059 MB/sec
+                 ·gc.alloc.rate.norm:              187816.005 B/op
+                 ·gc.churn.PS_Eden_Space:          2967.936 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     188252.224 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 10.780 B/op
+                 ·gc.count:                        91.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   4: 18011.672 ops/s
+                 ·gc.alloc.rate:                   2929.307 MB/sec
+                 ·gc.alloc.rate.norm:              187816.005 B/op
+                 ·gc.churn.PS_Eden_Space:          2928.178 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     187743.652 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.170 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 10.901 B/op
+                 ·gc.count:                        88.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 18050.859 ops/s
+                 ·gc.alloc.rate:                   2935.331 MB/sec
+                 ·gc.alloc.rate.norm:              187816.005 B/op
+                 ·gc.churn.PS_Eden_Space:          2936.206 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     187871.993 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.210 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 13.410 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         48.000 ms
+
+
+# Run progress: 80.56% complete, ETA 00:04:11
+# Fork: 2 of 2
+# Warmup Iteration   1: 5517.725 ops/s
+# Warmup Iteration   2: 12600.887 ops/s
+# Warmup Iteration   3: 14740.985 ops/s
+# Warmup Iteration   4: 16094.403 ops/s
+# Warmup Iteration   5: 18322.763 ops/s
+Iteration   1: 18178.584 ops/s
+                 ·gc.alloc.rate:                   2956.017 MB/sec
+                 ·gc.alloc.rate.norm:              187843.611 B/op
+                 ·gc.churn.PS_Eden_Space:          2953.255 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     187668.099 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.051 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.239 B/op
+                 ·gc.count:                        30.000 counts
+                 ·gc.time:                         16.000 ms
+
+Iteration   2: 17647.510 ops/s
+                 ·gc.alloc.rate:                   2873.139 MB/sec
+                 ·gc.alloc.rate.norm:              187832.005 B/op
+                 ·gc.churn.PS_Eden_Space:          2908.762 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     190160.912 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.165 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 10.755 B/op
+                 ·gc.count:                        84.000 counts
+                 ·gc.time:                         46.000 ms
+
+Iteration   3: 17569.780 ops/s
+                 ·gc.alloc.rate:                   2858.027 MB/sec
+                 ·gc.alloc.rate.norm:              187832.005 B/op
+                 ·gc.churn.PS_Eden_Space:          2842.265 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     186796.079 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.227 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 14.903 B/op
+                 ·gc.count:                        86.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   4: 18137.505 ops/s
+                 ·gc.alloc.rate:                   2950.059 MB/sec
+                 ·gc.alloc.rate.norm:              187832.005 B/op
+                 ·gc.churn.PS_Eden_Space:          2953.942 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     188079.239 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.193 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 12.282 B/op
+                 ·gc.count:                        90.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 17773.056 ops/s
+                 ·gc.alloc.rate:                   2890.757 MB/sec
+                 ·gc.alloc.rate.norm:              187832.005 B/op
+                 ·gc.churn.PS_Eden_Space:          2882.103 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     187269.700 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.181 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 11.782 B/op
+                 ·gc.count:                        86.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+
+Result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30":
+  17964.561 ±(99.9%) 338.013 ops/s [Average]
+  (min, avg, max) = (17569.780, 17964.561, 18207.234), stdev = 223.575
+  CI (99.9%): [17626.548, 18302.574] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30:·gc.alloc.rate":
+  2921.934 ±(99.9%) 53.928 MB/sec [Average]
+  (min, avg, max) = (2858.027, 2921.934, 2961.059), stdev = 35.670
+  CI (99.9%): [2868.006, 2975.862] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30:·gc.alloc.rate.norm":
+  187826.434 ±(99.9%) 14.773 B/op [Average]
+  (min, avg, max) = (187816.005, 187826.434, 187843.611), stdev = 9.771
+  CI (99.9%): [187811.661, 187841.207] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Eden_Space":
+  2938.398 ±(99.9%) 99.569 MB/sec [Average]
+  (min, avg, max) = (2842.265, 2938.398, 3092.997), stdev = 65.859
+  CI (99.9%): [2838.829, 3037.967] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Eden_Space.norm":
+  188879.762 ±(99.9%) 4891.242 B/op [Average]
+  (min, avg, max) = (186796.079, 188879.762, 197718.313), stdev = 3235.254
+  CI (99.9%): [183988.520, 193771.004] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Survivor_Space":
+  0.160 ±(99.9%) 0.091 MB/sec [Average]
+  (min, avg, max) = (0.051, 0.160, 0.227), stdev = 0.060
+  CI (99.9%): [0.068, 0.251] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Survivor_Space.norm":
+  10.295 ±(99.9%) 5.940 B/op [Average]
+  (min, avg, max) = (3.239, 10.295, 14.903), stdev = 3.929
+  CI (99.9%): [4.355, 16.234] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30:·gc.count":
+  769.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (30.000, 76.900, 92.000), stdev = 24.062
+  CI (99.9%): [769.000, 769.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30:·gc.time":
+  416.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (16.000, 41.600, 49.000), stdev = 12.747
+  CI (99.9%): [416.000, 416.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30_multibyte
+
+# Run progress: 83.33% complete, ETA 00:03:35
+# Fork: 1 of 2
+# Warmup Iteration   1: 1651.601 ops/s
+# Warmup Iteration   2: 3818.649 ops/s
+# Warmup Iteration   3: 3750.499 ops/s
+# Warmup Iteration   4: 4026.589 ops/s
+# Warmup Iteration   5: 4825.894 ops/s
+Iteration   1: 4907.255 ops/s
+                 ·gc.alloc.rate:                   2154.393 MB/sec
+                 ·gc.alloc.rate.norm:              506864.019 B/op
+                 ·gc.churn.PS_Eden_Space:          2152.116 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     506328.256 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.034 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 7.999 B/op
+                 ·gc.count:                        15.000 counts
+                 ·gc.time:                         11.000 ms
+
+Iteration   2: 4852.801 ops/s
+                 ·gc.alloc.rate:                   2129.631 MB/sec
+                 ·gc.alloc.rate.norm:              506858.519 B/op
+                 ·gc.churn.PS_Eden_Space:          2190.264 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     521289.357 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.210 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 49.888 B/op
+                 ·gc.count:                        52.000 counts
+                 ·gc.time:                         29.000 ms
+
+Iteration   3: 4794.059 ops/s
+                 ·gc.alloc.rate:                   2105.028 MB/sec
+                 ·gc.alloc.rate.norm:              506840.018 B/op
+                 ·gc.churn.PS_Eden_Space:          2099.511 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     505511.740 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.351 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 84.601 B/op
+                 ·gc.count:                        84.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   4: 4809.985 ops/s
+                 ·gc.alloc.rate:                   2112.558 MB/sec
+                 ·gc.alloc.rate.norm:              506836.481 B/op
+                 ·gc.churn.PS_Eden_Space:          2117.986 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     508138.518 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.329 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 78.897 B/op
+                 ·gc.count:                        84.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 4860.346 ops/s
+                 ·gc.alloc.rate:                   2132.809 MB/sec
+                 ·gc.alloc.rate.norm:              506816.019 B/op
+                 ·gc.churn.PS_Eden_Space:          2120.195 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     503818.616 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.363 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 86.278 B/op
+                 ·gc.count:                        87.000 counts
+                 ·gc.time:                         48.000 ms
+
+
+# Run progress: 86.11% complete, ETA 00:02:59
+# Fork: 2 of 2
+# Warmup Iteration   1: 1906.939 ops/s
+# Warmup Iteration   2: 3685.832 ops/s
+# Warmup Iteration   3: 3794.693 ops/s
+# Warmup Iteration   4: 4860.742 ops/s
+# Warmup Iteration   5: 4925.401 ops/s
+Iteration   1: 4849.836 ops/s
+                 ·gc.alloc.rate:                   2130.233 MB/sec
+                 ·gc.alloc.rate.norm:              506864.019 B/op
+                 ·gc.churn.PS_Eden_Space:          2192.379 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     521650.997 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.153 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 36.475 B/op
+                 ·gc.count:                        51.000 counts
+                 ·gc.time:                         29.000 ms
+
+Iteration   2: 4848.465 ops/s
+                 ·gc.alloc.rate:                   2129.528 MB/sec
+                 ·gc.alloc.rate.norm:              506870.289 B/op
+                 ·gc.churn.PS_Eden_Space:          2133.973 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     507928.268 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.312 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 74.289 B/op
+                 ·gc.count:                        82.000 counts
+                 ·gc.time:                         45.000 ms
+
+Iteration   3: 4848.577 ops/s
+                 ·gc.alloc.rate:                   2129.662 MB/sec
+                 ·gc.alloc.rate.norm:              506888.019 B/op
+                 ·gc.churn.PS_Eden_Space:          2118.510 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     504233.622 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.335 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 79.688 B/op
+                 ·gc.count:                        86.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   4: 4880.121 ops/s
+                 ·gc.alloc.rate:                   2142.706 MB/sec
+                 ·gc.alloc.rate.norm:              506869.748 B/op
+                 ·gc.churn.PS_Eden_Space:          2147.376 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     507974.433 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.323 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 76.470 B/op
+                 ·gc.count:                        92.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 4860.057 ops/s
+                 ·gc.alloc.rate:                   2134.210 MB/sec
+                 ·gc.alloc.rate.norm:              506816.018 B/op
+                 ·gc.churn.PS_Eden_Space:          2132.866 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     506496.833 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.380 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 90.303 B/op
+                 ·gc.count:                        92.000 counts
+                 ·gc.time:                         49.000 ms
+
+
+
+Result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30_multibyte":
+  4851.150 ±(99.9%) 48.135 ops/s [Average]
+  (min, avg, max) = (4794.059, 4851.150, 4907.255), stdev = 31.839
+  CI (99.9%): [4803.015, 4899.286] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.alloc.rate":
+  2130.076 ±(99.9%) 20.842 MB/sec [Average]
+  (min, avg, max) = (2105.028, 2130.076, 2154.393), stdev = 13.786
+  CI (99.9%): [2109.234, 2150.918] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.alloc.rate.norm":
+  506852.315 ±(99.9%) 36.518 B/op [Average]
+  (min, avg, max) = (506816.018, 506852.315, 506888.019), stdev = 24.155
+  CI (99.9%): [506815.796, 506888.833] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Eden_Space":
+  2140.517 ±(99.9%) 46.555 MB/sec [Average]
+  (min, avg, max) = (2099.511, 2140.517, 2192.379), stdev = 30.793
+  CI (99.9%): [2093.963, 2187.072] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Eden_Space.norm":
+  509337.064 ±(99.9%) 9926.962 B/op [Average]
+  (min, avg, max) = (503818.616, 509337.064, 521650.997), stdev = 6566.071
+  CI (99.9%): [499410.102, 519264.026] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space":
+  0.279 ±(99.9%) 0.169 MB/sec [Average]
+  (min, avg, max) = (0.034, 0.279, 0.380), stdev = 0.111
+  CI (99.9%): [0.111, 0.448] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space.norm":
+  66.489 ±(99.9%) 40.231 B/op [Average]
+  (min, avg, max) = (7.999, 66.489, 90.303), stdev = 26.610
+  CI (99.9%): [26.258, 106.720] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.count":
+  725.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (15.000, 72.500, 92.000), stdev = 25.158
+  CI (99.9%): [725.000, 725.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.time":
+  401.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (11.000, 40.100, 49.000), stdev = 12.819
+  CI (99.9%): [401.000, 401.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_10
+
+# Run progress: 88.89% complete, ETA 00:02:23
+# Fork: 1 of 2
+# Warmup Iteration   1: 26317.086 ops/s
+# Warmup Iteration   2: 121047.782 ops/s
+# Warmup Iteration   3: 124733.177 ops/s
+# Warmup Iteration   4: 153023.003 ops/s
+# Warmup Iteration   5: 151696.060 ops/s
+Iteration   1: 152715.643 ops/s
+                 ·gc.alloc.rate:                   2211.487 MB/sec
+                 ·gc.alloc.rate.norm:              16704.001 B/op
+                 ·gc.churn.PS_Eden_Space:          2249.505 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     16991.168 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.074 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.558 B/op
+                 ·gc.count:                        53.000 counts
+                 ·gc.time:                         29.000 ms
+
+Iteration   2: 139816.068 ops/s
+                 ·gc.alloc.rate:                   2022.930 MB/sec
+                 ·gc.alloc.rate.norm:              16704.001 B/op
+                 ·gc.churn.PS_Eden_Space:          2024.793 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     16719.384 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.142 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.171 B/op
+                 ·gc.count:                        80.000 counts
+                 ·gc.time:                         44.000 ms
+
+Iteration   3: 146496.986 ops/s
+                 ·gc.alloc.rate:                   2120.101 MB/sec
+                 ·gc.alloc.rate.norm:              16704.001 B/op
+                 ·gc.churn.PS_Eden_Space:          2110.270 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     16626.548 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.142 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.117 B/op
+                 ·gc.count:                        85.000 counts
+                 ·gc.time:                         46.000 ms
+
+Iteration   4: 144243.661 ops/s
+                 ·gc.alloc.rate:                   2088.130 MB/sec
+                 ·gc.alloc.rate.norm:              16704.001 B/op
+                 ·gc.churn.PS_Eden_Space:          2106.257 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     16849.009 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.159 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.271 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         49.000 ms
+
+Iteration   5: 142337.794 ops/s
+                 ·gc.alloc.rate:                   2059.384 MB/sec
+                 ·gc.alloc.rate.norm:              16704.001 B/op
+                 ·gc.churn.PS_Eden_Space:          2052.151 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     16645.338 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.136 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.105 B/op
+                 ·gc.count:                        85.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+# Run progress: 91.67% complete, ETA 00:01:47
+# Fork: 2 of 2
+# Warmup Iteration   1: 32619.039 ops/s
+# Warmup Iteration   2: 102876.795 ops/s
+# Warmup Iteration   3: 106534.630 ops/s
+# Warmup Iteration   4: 132273.705 ops/s
+# Warmup Iteration   5: 135430.404 ops/s
+Iteration   1: 136236.309 ops/s
+                 ·gc.alloc.rate:                   1956.451 MB/sec
+                 ·gc.alloc.rate.norm:              16576.001 B/op
+                 ·gc.churn.PS_Eden_Space:          2011.463 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     17042.088 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.074 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.625 B/op
+                 ·gc.count:                        36.000 counts
+                 ·gc.time:                         19.000 ms
+
+Iteration   2: 134855.913 ops/s
+                 ·gc.alloc.rate:                   1936.717 MB/sec
+                 ·gc.alloc.rate.norm:              16576.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1932.955 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     16543.796 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.136 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.165 B/op
+                 ·gc.count:                        88.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   3: 136666.187 ops/s
+                 ·gc.alloc.rate:                   1963.544 MB/sec
+                 ·gc.alloc.rate.norm:              16576.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1958.526 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     16533.637 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.113 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.958 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   4: 132970.555 ops/s
+                 ·gc.alloc.rate:                   1910.648 MB/sec
+                 ·gc.alloc.rate.norm:              16576.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1916.208 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     16624.237 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.165 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.429 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         49.000 ms
+
+Iteration   5: 134725.735 ops/s
+                 ·gc.alloc.rate:                   1934.573 MB/sec
+                 ·gc.alloc.rate.norm:              16576.001 B/op
+                 ·gc.churn.PS_Eden_Space:          1916.888 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     16424.470 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.136 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.167 B/op
+                 ·gc.count:                        79.000 counts
+                 ·gc.time:                         45.000 ms
+
+
+
+Result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_10":
+  140106.485 ±(99.9%) 9512.094 ops/s [Average]
+  (min, avg, max) = (132970.555, 140106.485, 152715.643), stdev = 6291.662
+  CI (99.9%): [130594.391, 149618.580] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_10:·gc.alloc.rate":
+  2020.396 ±(99.9%) 148.049 MB/sec [Average]
+  (min, avg, max) = (1910.648, 2020.396, 2211.487), stdev = 97.925
+  CI (99.9%): [1872.347, 2168.446] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_10:·gc.alloc.rate.norm":
+  16640.001 ±(99.9%) 101.993 B/op [Average]
+  (min, avg, max) = (16576.001, 16640.001, 16704.001), stdev = 67.462
+  CI (99.9%): [16538.008, 16741.993] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Eden_Space":
+  2027.902 ±(99.9%) 160.576 MB/sec [Average]
+  (min, avg, max) = (1916.208, 2027.902, 2249.505), stdev = 106.211
+  CI (99.9%): [1867.325, 2188.478] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Eden_Space.norm":
+  16699.967 ±(99.9%) 305.088 B/op [Average]
+  (min, avg, max) = (16424.470, 16699.967, 17042.088), stdev = 201.797
+  CI (99.9%): [16394.879, 17005.056] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Survivor_Space":
+  0.128 ±(99.9%) 0.048 MB/sec [Average]
+  (min, avg, max) = (0.074, 0.128, 0.165), stdev = 0.032
+  CI (99.9%): [0.080, 0.175] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Survivor_Space.norm":
+  1.057 ±(99.9%) 0.413 B/op [Average]
+  (min, avg, max) = (0.558, 1.057, 1.429), stdev = 0.273
+  CI (99.9%): [0.643, 1.470] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_10:·gc.count":
+  773.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (36.000, 77.300, 89.000), stdev = 18.105
+  CI (99.9%): [773.000, 773.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_10:·gc.time":
+  422.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (19.000, 42.200, 49.000), stdev = 9.998
+  CI (99.9%): [422.000, 422.000] (assumes normal distribution)
+
+
+# JMH 1.17.5 (released 29 days ago)
+# VM version: JDK 1.8.0_112, VM 25.112-b16
+# VM invoker: /Library/Java/JavaVirtualMachines/jdk1.8.0_112.jdk/Contents/Home/jre/bin/java
+# VM options: <none>
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 5 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_30
+
+# Run progress: 94.44% complete, ETA 00:01:11
+# Fork: 1 of 2
+# Warmup Iteration   1: 10692.136 ops/s
+# Warmup Iteration   2: 28744.389 ops/s
+# Warmup Iteration   3: 31874.288 ops/s
+# Warmup Iteration   4: 35182.588 ops/s
+# Warmup Iteration   5: 37461.924 ops/s
+Iteration   1: 39047.920 ops/s
+                 ·gc.alloc.rate:                   1927.955 MB/sec
+                 ·gc.alloc.rate.norm:              56952.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1930.828 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     57036.861 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.045 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 1.341 B/op
+                 ·gc.count:                        33.000 counts
+                 ·gc.time:                         17.000 ms
+
+Iteration   2: 38314.226 ops/s
+                 ·gc.alloc.rate:                   1889.983 MB/sec
+                 ·gc.alloc.rate.norm:              56952.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1880.954 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     56679.932 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.108 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.249 B/op
+                 ·gc.count:                        83.000 counts
+                 ·gc.time:                         46.000 ms
+
+Iteration   3: 37627.446 ops/s
+                 ·gc.alloc.rate:                   1857.852 MB/sec
+                 ·gc.alloc.rate.norm:              56952.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1876.595 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     57526.582 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.097 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.960 B/op
+                 ·gc.count:                        86.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   4: 38163.938 ops/s
+                 ·gc.alloc.rate:                   1883.564 MB/sec
+                 ·gc.alloc.rate.norm:              56952.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1877.824 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     56778.454 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.142 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 4.292 B/op
+                 ·gc.count:                        93.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 38878.552 ops/s
+                 ·gc.alloc.rate:                   1918.556 MB/sec
+                 ·gc.alloc.rate.norm:              56952.002 B/op
+                 ·gc.churn.PS_Eden_Space:          1909.856 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     56693.764 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.091 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.694 B/op
+                 ·gc.count:                        91.000 counts
+                 ·gc.time:                         49.000 ms
+
+
+# Run progress: 97.22% complete, ETA 00:00:35
+# Fork: 2 of 2
+# Warmup Iteration   1: 11446.031 ops/s
+# Warmup Iteration   2: 33048.270 ops/s
+# Warmup Iteration   3: 37100.881 ops/s
+# Warmup Iteration   4: 26070.927 ops/s
+# Warmup Iteration   5: 45151.726 ops/s
+Iteration   1: 43881.053 ops/s
+                 ·gc.alloc.rate:                   2165.741 MB/sec
+                 ·gc.alloc.rate.norm:              56952.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2261.319 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     59465.391 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.034 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 0.896 B/op
+                 ·gc.count:                        15.000 counts
+                 ·gc.time:                         10.000 ms
+
+Iteration   2: 43866.539 ops/s
+                 ·gc.alloc.rate:                   2165.776 MB/sec
+                 ·gc.alloc.rate.norm:              56952.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2251.483 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     59205.793 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.080 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.091 B/op
+                 ·gc.count:                        51.000 counts
+                 ·gc.time:                         28.000 ms
+
+Iteration   3: 44467.249 ops/s
+                 ·gc.alloc.rate:                   2194.880 MB/sec
+                 ·gc.alloc.rate.norm:              56952.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2196.759 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     57000.742 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.136 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.536 B/op
+                 ·gc.count:                        89.000 counts
+                 ·gc.time:                         47.000 ms
+
+Iteration   4: 44493.096 ops/s
+                 ·gc.alloc.rate:                   2195.428 MB/sec
+                 ·gc.alloc.rate.norm:              56952.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2187.791 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     56753.868 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.125 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 3.238 B/op
+                 ·gc.count:                        88.000 counts
+                 ·gc.time:                         48.000 ms
+
+Iteration   5: 44189.170 ops/s
+                 ·gc.alloc.rate:                   2180.812 MB/sec
+                 ·gc.alloc.rate.norm:              56952.002 B/op
+                 ·gc.churn.PS_Eden_Space:          2186.266 MB/sec
+                 ·gc.churn.PS_Eden_Space.norm:     57094.425 B/op
+                 ·gc.churn.PS_Survivor_Space:      0.108 MB/sec
+                 ·gc.churn.PS_Survivor_Space.norm: 2.817 B/op
+                 ·gc.count:                        91.000 counts
+                 ·gc.time:                         47.000 ms
+
+
+
+Result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_30":
+  41292.919 ±(99.9%) 4646.096 ops/s [Average]
+  (min, avg, max) = (37627.446, 41292.919, 44493.096), stdev = 3073.105
+  CI (99.9%): [36646.823, 45939.015] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_30:·gc.alloc.rate":
+  2038.055 ±(99.9%) 229.298 MB/sec [Average]
+  (min, avg, max) = (1857.852, 2038.055, 2195.428), stdev = 151.667
+  CI (99.9%): [1808.757, 2267.353] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_30:·gc.alloc.rate.norm":
+  56952.002 ±(99.9%) 0.001 B/op [Average]
+  (min, avg, max) = (56952.002, 56952.002, 56952.002), stdev = 0.001
+  CI (99.9%): [56952.002, 56952.002] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Eden_Space":
+  2055.967 ±(99.9%) 259.973 MB/sec [Average]
+  (min, avg, max) = (1876.595, 2055.967, 2261.319), stdev = 171.956
+  CI (99.9%): [1795.994, 2315.941] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Eden_Space.norm":
+  57423.581 ±(99.9%) 1573.019 B/op [Average]
+  (min, avg, max) = (56679.932, 57423.581, 59465.391), stdev = 1040.455
+  CI (99.9%): [55850.562, 58996.600] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Survivor_Space":
+  0.097 ±(99.9%) 0.054 MB/sec [Average]
+  (min, avg, max) = (0.034, 0.097, 0.142), stdev = 0.036
+  CI (99.9%): [0.042, 0.151] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Survivor_Space.norm":
+  2.711 ±(99.9%) 1.543 B/op [Average]
+  (min, avg, max) = (0.896, 2.711, 4.292), stdev = 1.021
+  CI (99.9%): [1.168, 4.255] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_30:·gc.count":
+  720.000 ±(99.9%) 0.001 counts [Sum]
+  (min, avg, max) = (15.000, 72.000, 93.000), stdev = 28.355
+  CI (99.9%): [720.000, 720.000] (assumes normal distribution)
+
+Secondary result "fluflu.msgpack.MessageUnpackerBenchmark.decodeString100_30:·gc.time":
+  387.000 ±(99.9%) 0.001 ms [Sum]
+  (min, avg, max) = (10.000, 38.700, 49.000), stdev = 14.712
+  CI (99.9%): [387.000, 387.000] (assumes normal distribution)
+
+
+# Run complete. Total time: 00:21:33
+
+Benchmark                                                                                 Mode  Cnt       Score       Error   Units
+MessagePackerBenchmark.encodeCirceAST                                                    thrpt   10   21999.482 ±   861.022   ops/s
+MessagePackerBenchmark.encodeCirceAST:·gc.alloc.rate                                     thrpt   10     652.313 ±    13.924  MB/sec
+MessagePackerBenchmark.encodeCirceAST:·gc.alloc.rate.norm                                thrpt   10   34232.282 ±   790.003    B/op
+MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Eden_Space                            thrpt   10     658.403 ±    26.519  MB/sec
+MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Eden_Space.norm                       thrpt   10   34546.227 ±   999.961    B/op
+MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Survivor_Space                        thrpt   10       0.114 ±     0.084  MB/sec
+MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Survivor_Space.norm                   thrpt   10       6.018 ±     4.469    B/op
+MessagePackerBenchmark.encodeCirceAST:·gc.count                                          thrpt   10     674.000              counts
+MessagePackerBenchmark.encodeCirceAST:·gc.time                                           thrpt   10     322.000                  ms
+MessagePackerBenchmark.encodeInt10                                                       thrpt   10  154755.729 ±  3020.968   ops/s
+MessagePackerBenchmark.encodeInt10:·gc.alloc.rate                                        thrpt   10    1364.765 ±    37.912  MB/sec
+MessagePackerBenchmark.encodeInt10:·gc.alloc.rate.norm                                   thrpt   10   10176.001 ±   127.491    B/op
+MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Eden_Space                               thrpt   10    1366.297 ±    36.197  MB/sec
+MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Eden_Space.norm                          thrpt   10   10187.596 ±   135.254    B/op
+MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Survivor_Space                           thrpt   10       0.159 ±     0.065  MB/sec
+MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Survivor_Space.norm                      thrpt   10       1.188 ±     0.480    B/op
+MessagePackerBenchmark.encodeInt10:·gc.count                                             thrpt   10     909.000              counts
+MessagePackerBenchmark.encodeInt10:·gc.time                                              thrpt   10     434.000                  ms
+MessagePackerBenchmark.encodeInt30                                                       thrpt   10   62693.637 ±  1706.851   ops/s
+MessagePackerBenchmark.encodeInt30:·gc.alloc.rate                                        thrpt   10    1334.699 ±    36.782  MB/sec
+MessagePackerBenchmark.encodeInt30:·gc.alloc.rate.norm                                   thrpt   10   24570.046 ±    38.206    B/op
+MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Eden_Space                               thrpt   10    1337.335 ±    48.742  MB/sec
+MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Eden_Space.norm                          thrpt   10   24617.316 ±   450.538    B/op
+MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Survivor_Space                           thrpt   10       0.150 ±     0.059  MB/sec
+MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Survivor_Space.norm                      thrpt   10       2.757 ±     1.080    B/op
+MessagePackerBenchmark.encodeInt30:·gc.count                                             thrpt   10     861.000              counts
+MessagePackerBenchmark.encodeInt30:·gc.time                                              thrpt   10     428.000                  ms
+MessagePackerBenchmark.encodeLong10                                                      thrpt   10  151138.125 ± 14021.495   ops/s
+MessagePackerBenchmark.encodeLong10:·gc.alloc.rate                                       thrpt   10    1287.154 ±   101.495  MB/sec
+MessagePackerBenchmark.encodeLong10:·gc.alloc.rate.norm                                  thrpt   10    9846.370 ±   716.577    B/op
+MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Eden_Space                              thrpt   10    1289.384 ±   112.219  MB/sec
+MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Eden_Space.norm                         thrpt   10    9863.567 ±   817.279    B/op
+MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Survivor_Space                          thrpt   10       0.133 ±     0.088  MB/sec
+MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Survivor_Space.norm                     thrpt   10       1.009 ±     0.658    B/op
+MessagePackerBenchmark.encodeLong10:·gc.count                                            thrpt   10     735.000              counts
+MessagePackerBenchmark.encodeLong10:·gc.time                                             thrpt   10     368.000                  ms
+MessagePackerBenchmark.encodeLong30                                                      thrpt   10   55535.395 ±  3690.269   ops/s
+MessagePackerBenchmark.encodeLong30:·gc.alloc.rate                                       thrpt   10    1427.448 ±   100.616  MB/sec
+MessagePackerBenchmark.encodeLong30:·gc.alloc.rate.norm                                  thrpt   10   29679.040 ±   113.962    B/op
+MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Eden_Space                              thrpt   10    1432.884 ±   109.017  MB/sec
+MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Eden_Space.norm                         thrpt   10   29788.365 ±   410.485    B/op
+MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Survivor_Space                          thrpt   10       0.152 ±     0.076  MB/sec
+MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Survivor_Space.norm                     thrpt   10       3.192 ±     1.641    B/op
+MessagePackerBenchmark.encodeLong30:·gc.count                                            thrpt   10     809.000              counts
+MessagePackerBenchmark.encodeLong30:·gc.time                                             thrpt   10     404.000                  ms
+MessagePackerBenchmark.encodeString1000_30                                               thrpt   10    3132.253 ±    50.695   ops/s
+MessagePackerBenchmark.encodeString1000_30:·gc.alloc.rate                                thrpt   10     485.230 ±     7.901  MB/sec
+MessagePackerBenchmark.encodeString1000_30:·gc.alloc.rate.norm                           thrpt   10  178849.522 ±    22.576    B/op
+MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Eden_Space                       thrpt   10     488.733 ±    13.168  MB/sec
+MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Eden_Space.norm                  thrpt   10  180131.026 ±  2464.308    B/op
+MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Survivor_Space                   thrpt   10       0.135 ±     0.091  MB/sec
+MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Survivor_Space.norm              thrpt   10      49.714 ±    33.974    B/op
+MessagePackerBenchmark.encodeString1000_30:·gc.count                                     thrpt   10     629.000              counts
+MessagePackerBenchmark.encodeString1000_30:·gc.time                                      thrpt   10     300.000                  ms
+MessagePackerBenchmark.encodeString1000_30_multibyte                                     thrpt   10     787.964 ±    13.937   ops/s
+MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.alloc.rate                      thrpt   10     486.428 ±     7.863  MB/sec
+MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.alloc.rate.norm                 thrpt   10  712512.844 ±  2377.381    B/op
+MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Eden_Space             thrpt   10     490.093 ±    10.002  MB/sec
+MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Eden_Space.norm        thrpt   10  717928.399 ± 16106.302    B/op
+MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space         thrpt   10       0.316 ±     0.238  MB/sec
+MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space.norm    thrpt   10     463.148 ±   349.282    B/op
+MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.count                           thrpt   10     628.000              counts
+MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.time                            thrpt   10     301.000                  ms
+MessagePackerBenchmark.encodeString100_10                                                thrpt   10   60629.525 ±  2620.244   ops/s
+MessagePackerBenchmark.encodeString100_10:·gc.alloc.rate                                 thrpt   10     919.083 ±    39.230  MB/sec
+MessagePackerBenchmark.encodeString100_10:·gc.alloc.rate.norm                            thrpt   10   17496.001 ±    12.749    B/op
+MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Eden_Space                        thrpt   10     925.436 ±    51.134  MB/sec
+MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Eden_Space.norm                   thrpt   10   17614.061 ±   338.477    B/op
+MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Survivor_Space                    thrpt   10       0.127 ±     0.081  MB/sec
+MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Survivor_Space.norm               thrpt   10       2.419 ±     1.570    B/op
+MessagePackerBenchmark.encodeString100_10:·gc.count                                      thrpt   10     744.000              counts
+MessagePackerBenchmark.encodeString100_10:·gc.time                                       thrpt   10     360.000                  ms
+MessagePackerBenchmark.encodeString100_30                                                thrpt   10   19754.603 ±   507.517   ops/s
+MessagePackerBenchmark.encodeString100_30:·gc.alloc.rate                                 thrpt   10     725.594 ±    61.802  MB/sec
+MessagePackerBenchmark.encodeString100_30:·gc.alloc.rate.norm                            thrpt   10   42369.959 ±  2818.773    B/op
+MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Eden_Space                        thrpt   10     730.316 ±    63.586  MB/sec
+MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Eden_Space.norm                   thrpt   10   42645.930 ±  2959.086    B/op
+MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Survivor_Space                    thrpt   10       0.128 ±     0.082  MB/sec
+MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Survivor_Space.norm               thrpt   10       7.456 ±     4.781    B/op
+MessagePackerBenchmark.encodeString100_30:·gc.count                                      thrpt   10     712.000              counts
+MessagePackerBenchmark.encodeString100_30:·gc.time                                       thrpt   10     345.000                  ms
+MessageUnpackerBenchmark.decodeCirceAST                                                  thrpt   10   47815.540 ±  2406.587   ops/s
+MessageUnpackerBenchmark.decodeCirceAST:·gc.alloc.rate                                   thrpt   10    2073.922 ±   104.439  MB/sec
+MessageUnpackerBenchmark.decodeCirceAST:·gc.alloc.rate.norm                              thrpt   10   50056.002 ±     0.001    B/op
+MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Eden_Space                          thrpt   10    2078.066 ±   110.347  MB/sec
+MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Eden_Space.norm                     thrpt   10   50153.781 ±   378.324    B/op
+MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Survivor_Space                      thrpt   10       0.120 ±     0.081  MB/sec
+MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Survivor_Space.norm                 thrpt   10       2.903 ±     2.003    B/op
+MessageUnpackerBenchmark.decodeCirceAST:·gc.count                                        thrpt   10     742.000              counts
+MessageUnpackerBenchmark.decodeCirceAST:·gc.time                                         thrpt   10     395.000                  ms
+MessageUnpackerBenchmark.decodeInt10                                                     thrpt   10  185552.826 ±  8690.670   ops/s
+MessageUnpackerBenchmark.decodeInt10:·gc.alloc.rate                                      thrpt   10    1727.484 ±   109.444  MB/sec
+MessageUnpackerBenchmark.decodeInt10:·gc.alloc.rate.norm                                 thrpt   10   10744.000 ±   191.236    B/op
+MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Eden_Space                             thrpt   10    1729.565 ±   109.369  MB/sec
+MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Eden_Space.norm                        thrpt   10   10757.250 ±   222.406    B/op
+MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Survivor_Space                         thrpt   10       0.134 ±     0.085  MB/sec
+MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Survivor_Space.norm                    thrpt   10       0.836 ±     0.525    B/op
+MessageUnpackerBenchmark.decodeInt10:·gc.count                                           thrpt   10     755.000              counts
+MessageUnpackerBenchmark.decodeInt10:·gc.time                                            thrpt   10     415.000                  ms
+MessageUnpackerBenchmark.decodeInt30                                                     thrpt   10   54623.655 ±  1566.356   ops/s
+MessageUnpackerBenchmark.decodeInt30:·gc.alloc.rate                                      thrpt   10    1863.184 ±    53.357  MB/sec
+MessageUnpackerBenchmark.decodeInt30:·gc.alloc.rate.norm                                 thrpt   10   39392.002 ±     0.001    B/op
+MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Eden_Space                             thrpt   10    1871.713 ±    66.368  MB/sec
+MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Eden_Space.norm                        thrpt   10   39571.182 ±   660.999    B/op
+MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Survivor_Space                         thrpt   10       0.125 ±     0.069  MB/sec
+MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Survivor_Space.norm                    thrpt   10       2.643 ±     1.485    B/op
+MessageUnpackerBenchmark.decodeInt30:·gc.count                                           thrpt   10     774.000              counts
+MessageUnpackerBenchmark.decodeInt30:·gc.time                                            thrpt   10     416.000                  ms
+MessageUnpackerBenchmark.decodeLong10                                                    thrpt   10   62970.425 ±  3333.483   ops/s
+MessageUnpackerBenchmark.decodeLong10:·gc.alloc.rate                                     thrpt   10    1870.110 ±    85.046  MB/sec
+MessageUnpackerBenchmark.decodeLong10:·gc.alloc.rate.norm                                thrpt   10   34304.001 ±   267.731    B/op
+MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Eden_Space                            thrpt   10    1880.583 ±    89.865  MB/sec
+MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Eden_Space.norm                       thrpt   10   34497.888 ±   807.360    B/op
+MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Survivor_Space                        thrpt   10       0.109 ±     0.065  MB/sec
+MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Survivor_Space.norm                   thrpt   10       1.995 ±     1.191    B/op
+MessageUnpackerBenchmark.decodeLong10:·gc.count                                          thrpt   10     728.000              counts
+MessageUnpackerBenchmark.decodeLong10:·gc.time                                           thrpt   10     402.000                  ms
+MessageUnpackerBenchmark.decodeLong30                                                    thrpt   10   20415.256 ±   206.602   ops/s
+MessageUnpackerBenchmark.decodeLong30:·gc.alloc.rate                                     thrpt   10    1910.141 ±    19.325  MB/sec
+MessageUnpackerBenchmark.decodeLong30:·gc.alloc.rate.norm                                thrpt   10  108025.595 ±     5.072    B/op
+MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Eden_Space                            thrpt   10    1913.532 ±    33.248  MB/sec
+MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Eden_Space.norm                       thrpt   10  108215.103 ±  1041.463    B/op
+MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Survivor_Space                        thrpt   10       0.117 ±     0.028  MB/sec
+MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Survivor_Space.norm                   thrpt   10       6.606 ±     1.625    B/op
+MessageUnpackerBenchmark.decodeLong30:·gc.count                                          thrpt   10     839.000              counts
+MessageUnpackerBenchmark.decodeLong30:·gc.time                                           thrpt   10     460.000                  ms
+MessageUnpackerBenchmark.decodeString1000_30                                             thrpt   10   17964.561 ±   338.013   ops/s
+MessageUnpackerBenchmark.decodeString1000_30:·gc.alloc.rate                              thrpt   10    2921.934 ±    53.928  MB/sec
+MessageUnpackerBenchmark.decodeString1000_30:·gc.alloc.rate.norm                         thrpt   10  187826.434 ±    14.773    B/op
+MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Eden_Space                     thrpt   10    2938.398 ±    99.569  MB/sec
+MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Eden_Space.norm                thrpt   10  188879.762 ±  4891.242    B/op
+MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Survivor_Space                 thrpt   10       0.160 ±     0.091  MB/sec
+MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Survivor_Space.norm            thrpt   10      10.295 ±     5.940    B/op
+MessageUnpackerBenchmark.decodeString1000_30:·gc.count                                   thrpt   10     769.000              counts
+MessageUnpackerBenchmark.decodeString1000_30:·gc.time                                    thrpt   10     416.000                  ms
+MessageUnpackerBenchmark.decodeString1000_30_multibyte                                   thrpt   10    4851.150 ±    48.135   ops/s
+MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.alloc.rate                    thrpt   10    2130.076 ±    20.842  MB/sec
+MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.alloc.rate.norm               thrpt   10  506852.315 ±    36.518    B/op
+MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Eden_Space           thrpt   10    2140.517 ±    46.555  MB/sec
+MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Eden_Space.norm      thrpt   10  509337.064 ±  9926.962    B/op
+MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space       thrpt   10       0.279 ±     0.169  MB/sec
+MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space.norm  thrpt   10      66.489 ±    40.231    B/op
+MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.count                         thrpt   10     725.000              counts
+MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.time                          thrpt   10     401.000                  ms
+MessageUnpackerBenchmark.decodeString100_10                                              thrpt   10  140106.485 ±  9512.094   ops/s
+MessageUnpackerBenchmark.decodeString100_10:·gc.alloc.rate                               thrpt   10    2020.396 ±   148.049  MB/sec
+MessageUnpackerBenchmark.decodeString100_10:·gc.alloc.rate.norm                          thrpt   10   16640.001 ±   101.993    B/op
+MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Eden_Space                      thrpt   10    2027.902 ±   160.576  MB/sec
+MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Eden_Space.norm                 thrpt   10   16699.967 ±   305.088    B/op
+MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Survivor_Space                  thrpt   10       0.128 ±     0.048  MB/sec
+MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Survivor_Space.norm             thrpt   10       1.057 ±     0.413    B/op
+MessageUnpackerBenchmark.decodeString100_10:·gc.count                                    thrpt   10     773.000              counts
+MessageUnpackerBenchmark.decodeString100_10:·gc.time                                     thrpt   10     422.000                  ms
+MessageUnpackerBenchmark.decodeString100_30                                              thrpt   10   41292.919 ±  4646.096   ops/s
+MessageUnpackerBenchmark.decodeString100_30:·gc.alloc.rate                               thrpt   10    2038.055 ±   229.298  MB/sec
+MessageUnpackerBenchmark.decodeString100_30:·gc.alloc.rate.norm                          thrpt   10   56952.002 ±     0.001    B/op
+MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Eden_Space                      thrpt   10    2055.967 ±   259.973  MB/sec
+MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Eden_Space.norm                 thrpt   10   57423.581 ±  1573.019    B/op
+MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Survivor_Space                  thrpt   10       0.097 ±     0.054  MB/sec
+MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Survivor_Space.norm             thrpt   10       2.711 ±     1.543    B/op
+MessageUnpackerBenchmark.decodeString100_30:·gc.count                                    thrpt   10     720.000              counts
+MessageUnpackerBenchmark.decodeString100_30:·gc.time                                     thrpt   10     387.000                  ms
+[success] Total time: 1328 s, completed Mar 25, 2017 9:49:07 AM

--- a/msgpack/src/main/scala/fluflu/msgpack/MessagePacker.scala
+++ b/msgpack/src/main/scala/fluflu/msgpack/MessagePacker.scala
@@ -13,7 +13,7 @@ import scala.util.{ Either => \/ }
 
 object MessagePacker {
 
-  private[this] val encoder: ThreadLocal[CharsetEncoder] = new ThreadLocal[CharsetEncoder] {
+  private[this] val encoders: ThreadLocal[CharsetEncoder] = new ThreadLocal[CharsetEncoder] {
     override def initialValue(): CharsetEncoder = StandardCharsets.UTF_8.newEncoder()
   }
 
@@ -110,7 +110,7 @@ object MessagePacker {
 
   def formatStrFamily(v: String, builder: mutable.ArrayBuilder[Byte]): Unit = {
     val cb = CharBuffer.wrap(v)
-    val buf = encoder.get.encode(cb)
+    val buf = encoders.get.encode(cb)
     val len = buf.remaining()
     formatStrFamilyHeader(len, builder)
     val arr = Array.ofDim[Byte](len)


### PR DESCRIPTION
This PR, I tried `ThreadLocal` to store the `CharsetDecoder`. Decode performance has been improved slightly.