### PR TITLE
🔧 Add restart condition

### DIFF
--- a/queue/src/main/scala/fluflu/queue/Client.scala
+++ b/queue/src/main/scala/fluflu/queue/Client.scala
@@ -95,7 +95,7 @@ object Client {
         else {
           consume()
           running.set(false)
-          if (!scheduler.isShutdown) start()
+          if (!scheduler.isShutdown || !msgQueue.isEmpty) start()
         }
 
       def close(): Unit = {


### PR DESCRIPTION
Restart conusme is unnecessary when message queue is empty.