### PR TITLE
Refactor to replace the accumulator from Vector with VectorBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,33 +24,33 @@ And, so look at this [example](https://github.com/tkrs/fluflu/tree/master/module
 Encoder
 
 ```
-[info] Benchmark                                              Mode  Cnt       Score       Error  Units
-[info] MessagePackerBenchmark.encodeCirceAST                 thrpt   20  128408.501 ±  1866.924  ops/s
-[info] MessagePackerBenchmark.encodeInt10                    thrpt   20  315999.334 ±  4285.059  ops/s
-[info] MessagePackerBenchmark.encodeInt30                    thrpt   20  143539.468 ± 13205.880  ops/s
-[info] MessagePackerBenchmark.encodeLong10                   thrpt   20  343151.509 ± 19161.044  ops/s
-[info] MessagePackerBenchmark.encodeLong30                   thrpt   20  145687.290 ±  5606.780  ops/s
-[info] MessagePackerBenchmark.encodeNested                   thrpt   20  102871.196 ±  1771.029  ops/s
-[info] MessagePackerBenchmark.encodeString1000_30            thrpt   20   10593.208 ±    96.932  ops/s
-[info] MessagePackerBenchmark.encodeString1000_30_multibyte  thrpt   20    2395.656 ±    28.052  ops/s
-[info] MessagePackerBenchmark.encodeString100_10             thrpt   20  239773.304 ±  5713.490  ops/s
-[info] MessagePackerBenchmark.encodeString100_30             thrpt   20  105076.870 ±  1324.373  ops/s
+[info] Benchmark                                                Mode  Cnt       Score       Error   Units
+[info] MessagePackerBenchmark.encodeCirceAST                   thrpt   20  133167.141 ±  2550.616   ops/s
+[info] MessagePackerBenchmark.encodeInt10                      thrpt   20  370109.732 ±  9878.608   ops/s
+[info] MessagePackerBenchmark.encodeInt30                      thrpt   20  143915.592 ± 29259.983   ops/s
+[info] MessagePackerBenchmark.encodeLong10                     thrpt   20  340296.568 ±  5333.504   ops/s
+[info] MessagePackerBenchmark.encodeLong30                     thrpt   20  153223.090 ±  2857.427   ops/s
+[info] MessagePackerBenchmark.encodeNested                     thrpt   20  103858.391 ±  2043.339   ops/s
+[info] MessagePackerBenchmark.encodeString1000_30              thrpt   20   10661.082 ±   181.357   ops/s
+[info] MessagePackerBenchmark.encodeString1000_30_multibyte    thrpt   20    2340.150 ±    51.082   ops/s
+[info] MessagePackerBenchmark.encodeString100_10               thrpt   20  253301.605 ±  6416.145   ops/s
+[info] MessagePackerBenchmark.encodeString100_30               thrpt   20  107762.022 ±  2849.293   ops/s
 ```
 
 Decoder
 
 ```
-[info] Benchmark                                                Mode  Cnt       Score      Error  Units
-[info] MessageUnpackerBenchmark.decodeCirceAST                 thrpt   20  118432.943 ± 1295.806  ops/s
-[info] MessageUnpackerBenchmark.decodeInt10                    thrpt   20  261754.469 ± 3832.825  ops/s
-[info] MessageUnpackerBenchmark.decodeInt30                    thrpt   20  114688.456 ± 2408.395  ops/s
-[info] MessageUnpackerBenchmark.decodeLong10                   thrpt   20  110070.005 ± 1526.381  ops/s
-[info] MessageUnpackerBenchmark.decodeLong30                   thrpt   20   41417.811 ± 1033.903  ops/s
-[info] MessageUnpackerBenchmark.decodeNested                   thrpt   20  103433.867 ± 2209.280  ops/s
-[info] MessageUnpackerBenchmark.decodeString1000_30            thrpt   20   33895.083 ±  402.245  ops/s
-[info] MessageUnpackerBenchmark.decodeString1000_30_multibyte  thrpt   20    5183.450 ±   67.308  ops/s
-[info] MessageUnpackerBenchmark.decodeString100_10             thrpt   20  214975.326 ± 4839.443  ops/s
-[info] MessageUnpackerBenchmark.decodeString100_30             thrpt   20   92710.917 ± 1210.946  ops/s
+[info] Benchmark                                                Mode  Cnt       Score       Error   Units
+[info] MessageUnpackerBenchmark.decodeCirceAST                 thrpt   20  128765.305 ±  7875.374   ops/s
+[info] MessageUnpackerBenchmark.decodeInt10                    thrpt   20  292540.216 ±  8016.177   ops/s
+[info] MessageUnpackerBenchmark.decodeInt30                    thrpt   20  130384.440 ±  5428.657   ops/s
+[info] MessageUnpackerBenchmark.decodeLong10                   thrpt   20  116669.811 ±  2423.805   ops/s
+[info] MessageUnpackerBenchmark.decodeLong30                   thrpt   20   42903.651 ±  1197.532   ops/s
+[info] MessageUnpackerBenchmark.decodeNested                   thrpt   20  105284.983 ±  2737.642   ops/s
+[info] MessageUnpackerBenchmark.decodeString1000_30            thrpt   20   35019.191 ±   808.341   ops/s
+[info] MessageUnpackerBenchmark.decodeString1000_30_multibyte  thrpt   20    5053.968 ±    49.745   ops/s
+[info] MessageUnpackerBenchmark.decodeString100_10             thrpt   20  221799.362 ±  4139.716   ops/s
+[info] MessageUnpackerBenchmark.decodeString100_30             thrpt   20   96945.679 ±  3381.020   ops/s
 ```
 
 ## LICENSE

--- a/modules/benchmark/src/test/scala/fluflu/msgpack/MessageUnpackerBenchmark.scala
+++ b/modules/benchmark/src/test/scala/fluflu/msgpack/MessageUnpackerBenchmark.scala
@@ -8,8 +8,8 @@ import org.openjdk.jmh.annotations._
 
 @State(Scope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
-@Warmup(iterations = 5, time = 1)
-@Measurement(iterations = 10, time = 3)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @Fork(2)
 class MessageUnpackerBenchmark extends TestData {


### PR DESCRIPTION
This PR slightly improve the performance of the decoder. Closes #154. 

```
[info] Benchmark                                                                                 Mode  Cnt       Score       Error   Units
[info] MessagePackerBenchmark.encodeCirceAST                                                    thrpt   20  133167.141 ±  2550.616   ops/s
[info] MessagePackerBenchmark.encodeCirceAST:·gc.alloc.rate                                     thrpt   20    2997.344 ±    57.468  MB/sec
[info] MessagePackerBenchmark.encodeCirceAST:·gc.alloc.rate.norm                                thrpt   20   35440.013 ±    28.510    B/op
[info] MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Eden_Space                            thrpt   20    3000.586 ±    76.438  MB/sec
[info] MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Eden_Space.norm                       thrpt   20   35483.456 ±   804.174    B/op
[info] MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Survivor_Space                        thrpt   20       0.122 ±     0.038  MB/sec
[info] MessagePackerBenchmark.encodeCirceAST:·gc.churn.PS_Survivor_Space.norm                   thrpt   20       1.446 ±     0.448    B/op
[info] MessagePackerBenchmark.encodeCirceAST:·gc.count                                          thrpt   20     362.000              counts
[info] MessagePackerBenchmark.encodeCirceAST:·gc.time                                           thrpt   20     185.000                  ms
[info] MessagePackerBenchmark.encodeInt10                                                       thrpt   20  370109.732 ±  9878.608   ops/s
[info] MessagePackerBenchmark.encodeInt10:·gc.alloc.rate                                        thrpt   20    3484.486 ±    89.626  MB/sec
[info] MessagePackerBenchmark.encodeInt10:·gc.alloc.rate.norm                                   thrpt   20   14828.004 ±    24.946    B/op
[info] MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Eden_Space                               thrpt   20    3495.716 ±   149.292  MB/sec
[info] MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Eden_Space.norm                          thrpt   20   14875.456 ±   504.323    B/op
[info] MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Survivor_Space                           thrpt   20       0.122 ±     0.053  MB/sec
[info] MessagePackerBenchmark.encodeInt10:·gc.churn.PS_Survivor_Space.norm                      thrpt   20       0.523 ±     0.232    B/op
[info] MessagePackerBenchmark.encodeInt10:·gc.count                                             thrpt   20     358.000              counts
[info] MessagePackerBenchmark.encodeInt10:·gc.time                                              thrpt   20     188.000                  ms
[info] MessagePackerBenchmark.encodeInt30                                                       thrpt   20  143915.592 ± 29259.983   ops/s
[info] MessagePackerBenchmark.encodeInt30:·gc.alloc.rate                                        thrpt   20    2328.849 ±   473.245  MB/sec
[info] MessagePackerBenchmark.encodeInt30:·gc.alloc.rate.norm                                   thrpt   20   25480.011 ±     0.021    B/op
[info] MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Eden_Space                               thrpt   20    2338.318 ±   505.738  MB/sec
[info] MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Eden_Space.norm                          thrpt   20   25404.196 ±  1274.560    B/op
[info] MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Survivor_Space                           thrpt   20       0.102 ±     0.047  MB/sec
[info] MessagePackerBenchmark.encodeInt30:·gc.churn.PS_Survivor_Space.norm                      thrpt   20       1.085 ±     0.406    B/op
[info] MessagePackerBenchmark.encodeInt30:·gc.count                                             thrpt   20     308.000              counts
[info] MessagePackerBenchmark.encodeInt30:·gc.time                                              thrpt   20     201.000                  ms
[info] MessagePackerBenchmark.encodeLong10                                                      thrpt   20  340296.568 ±  5333.504   ops/s
[info] MessagePackerBenchmark.encodeLong10:·gc.alloc.rate                                       thrpt   20    3259.662 ±    51.566  MB/sec
[info] MessagePackerBenchmark.encodeLong10:·gc.alloc.rate.norm                                  thrpt   20   15088.005 ±     7.127    B/op
[info] MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Eden_Space                              thrpt   20    3263.343 ±    77.121  MB/sec
[info] MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Eden_Space.norm                         thrpt   20   15106.311 ±   318.218    B/op
[info] MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Survivor_Space                          thrpt   20       0.121 ±     0.029  MB/sec
[info] MessagePackerBenchmark.encodeLong10:·gc.churn.PS_Survivor_Space.norm                     thrpt   20       0.562 ±     0.135    B/op
[info] MessagePackerBenchmark.encodeLong10:·gc.count                                            thrpt   20     385.000              counts
[info] MessagePackerBenchmark.encodeLong10:·gc.time                                             thrpt   20     199.000                  ms
[info] MessagePackerBenchmark.encodeLong30                                                      thrpt   20  153223.090 ±  2857.427   ops/s
[info] MessagePackerBenchmark.encodeLong30:·gc.alloc.rate                                       thrpt   20    2541.596 ±    47.385  MB/sec
[info] MessagePackerBenchmark.encodeLong30:·gc.alloc.rate.norm                                  thrpt   20   26120.011 ±     0.022    B/op
[info] MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Eden_Space                              thrpt   20    2544.494 ±    50.983  MB/sec
[info] MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Eden_Space.norm                         thrpt   20   26153.690 ±   448.716    B/op
[info] MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Survivor_Space                          thrpt   20       0.113 ±     0.024  MB/sec
[info] MessagePackerBenchmark.encodeLong30:·gc.churn.PS_Survivor_Space.norm                     thrpt   20       1.162 ±     0.246    B/op
[info] MessagePackerBenchmark.encodeLong30:·gc.count                                            thrpt   20     384.000              counts
[info] MessagePackerBenchmark.encodeLong30:·gc.time                                             thrpt   20     197.000                  ms
[info] MessagePackerBenchmark.encodeNested                                                      thrpt   20  103858.391 ±  2043.339   ops/s
[info] MessagePackerBenchmark.encodeNested:·gc.alloc.rate                                       thrpt   20    2422.044 ±    47.164  MB/sec
[info] MessagePackerBenchmark.encodeNested:·gc.alloc.rate.norm                                  thrpt   20   36720.016 ±    21.382    B/op
[info] MessagePackerBenchmark.encodeNested:·gc.churn.PS_Eden_Space                              thrpt   20    2421.663 ±    63.587  MB/sec
[info] MessagePackerBenchmark.encodeNested:·gc.churn.PS_Eden_Space.norm                         thrpt   20   36713.130 ±   581.270    B/op
[info] MessagePackerBenchmark.encodeNested:·gc.churn.PS_Survivor_Space                          thrpt   20       0.091 ±     0.032  MB/sec
[info] MessagePackerBenchmark.encodeNested:·gc.churn.PS_Survivor_Space.norm                     thrpt   20       1.383 ±     0.487    B/op
[info] MessagePackerBenchmark.encodeNested:·gc.count                                            thrpt   20     374.000              counts
[info] MessagePackerBenchmark.encodeNested:·gc.time                                             thrpt   20     190.000                  ms
[info] MessagePackerBenchmark.encodeString1000_30                                               thrpt   20   10661.082 ±   181.357   ops/s
[info] MessagePackerBenchmark.encodeString1000_30:·gc.alloc.rate                                thrpt   20     875.601 ±    14.835  MB/sec
[info] MessagePackerBenchmark.encodeString1000_30:·gc.alloc.rate.norm                           thrpt   20  129291.141 ±     6.410    B/op
[info] MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Eden_Space                       thrpt   20     888.080 ±    50.411  MB/sec
[info] MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Eden_Space.norm                  thrpt   20  131134.161 ±  7105.193    B/op
[info] MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Survivor_Space                   thrpt   20       0.139 ±     0.067  MB/sec
[info] MessagePackerBenchmark.encodeString1000_30:·gc.churn.PS_Survivor_Space.norm              thrpt   20      20.599 ±    10.014    B/op
[info] MessagePackerBenchmark.encodeString1000_30:·gc.count                                     thrpt   20     240.000              counts
[info] MessagePackerBenchmark.encodeString1000_30:·gc.time                                      thrpt   20     128.000                  ms
[info] MessagePackerBenchmark.encodeString1000_30_multibyte                                     thrpt   20    2340.150 ±    51.082   ops/s
[info] MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.alloc.rate                      thrpt   20     732.267 ±    16.089  MB/sec
[info] MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.alloc.rate.norm                 thrpt   20  493424.706 ±     1.383    B/op
[info] MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Eden_Space             thrpt   20     746.701 ±    54.518  MB/sec
[info] MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Eden_Space.norm        thrpt   20  502975.003 ± 32214.190    B/op
[info] MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space         thrpt   20       0.565 ±     0.275  MB/sec
[info] MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space.norm    thrpt   20     384.222 ±   188.464    B/op
[info] MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.count                           thrpt   20     231.000              counts
[info] MessagePackerBenchmark.encodeString1000_30_multibyte:·gc.time                            thrpt   20     125.000                  ms
[info] MessagePackerBenchmark.encodeString100_10                                                thrpt   20  253301.605 ±  6416.145   ops/s
[info] MessagePackerBenchmark.encodeString100_10:·gc.alloc.rate                                 thrpt   20    3195.517 ±    81.627  MB/sec
[info] MessagePackerBenchmark.encodeString100_10:·gc.alloc.rate.norm                            thrpt   20   19888.007 ±     0.013    B/op
[info] MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Eden_Space                        thrpt   20    3193.459 ±    97.251  MB/sec
[info] MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Eden_Space.norm                   thrpt   20   19876.354 ±   377.400    B/op
[info] MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Survivor_Space                    thrpt   20       0.121 ±     0.037  MB/sec
[info] MessagePackerBenchmark.encodeString100_10:·gc.churn.PS_Survivor_Space.norm               thrpt   20       0.751 ±     0.229    B/op
[info] MessagePackerBenchmark.encodeString100_10:·gc.count                                      thrpt   20     365.000              counts
[info] MessagePackerBenchmark.encodeString100_10:·gc.time                                       thrpt   20     188.000                  ms
[info] MessagePackerBenchmark.encodeString100_30                                                thrpt   20  107762.022 ±  2849.293   ops/s
[info] MessagePackerBenchmark.encodeString100_30:·gc.alloc.rate                                 thrpt   20    2777.412 ±    76.398  MB/sec
[info] MessagePackerBenchmark.encodeString100_30:·gc.alloc.rate.norm                            thrpt   20   40648.015 ±     0.029    B/op
[info] MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Eden_Space                        thrpt   20    2777.656 ±   104.416  MB/sec
[info] MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Eden_Space.norm                   thrpt   20   40649.106 ±   966.349    B/op
[info] MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Survivor_Space                    thrpt   20       0.101 ±     0.027  MB/sec
[info] MessagePackerBenchmark.encodeString100_30:·gc.churn.PS_Survivor_Space.norm               thrpt   20       1.479 ±     0.381    B/op
[info] MessagePackerBenchmark.encodeString100_30:·gc.count                                      thrpt   20     335.000              counts
[info] MessagePackerBenchmark.encodeString100_30:·gc.time                                       thrpt   20     183.000                  ms
[info] MessageUnpackerBenchmark.decodeCirceAST                                                  thrpt   20  128765.305 ±  7875.374   ops/s
[info] MessageUnpackerBenchmark.decodeCirceAST:·gc.alloc.rate                                   thrpt   20    2681.538 ±   164.029  MB/sec
[info] MessageUnpackerBenchmark.decodeCirceAST:·gc.alloc.rate.norm                              thrpt   20   32804.013 ±    17.818    B/op
[info] MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Eden_Space                          thrpt   20    2689.399 ±   195.942  MB/sec
[info] MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Eden_Space.norm                     thrpt   20   32874.782 ±   753.622    B/op
[info] MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Survivor_Space                      thrpt   20       0.077 ±     0.037  MB/sec
[info] MessageUnpackerBenchmark.decodeCirceAST:·gc.churn.PS_Survivor_Space.norm                 thrpt   20       0.936 ±     0.440    B/op
[info] MessageUnpackerBenchmark.decodeCirceAST:·gc.count                                        thrpt   20     310.000              counts
[info] MessageUnpackerBenchmark.decodeCirceAST:·gc.time                                         thrpt   20     179.000                  ms
[info] MessageUnpackerBenchmark.decodeInt10                                                     thrpt   20  292540.216 ±  8016.177   ops/s
[info] MessageUnpackerBenchmark.decodeInt10:·gc.alloc.rate                                      thrpt   20    4220.561 ±   117.839  MB/sec
[info] MessageUnpackerBenchmark.decodeInt10:·gc.alloc.rate.norm                                 thrpt   20   22728.006 ±     0.012    B/op
[info] MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Eden_Space                             thrpt   20    4226.299 ±   170.927  MB/sec
[info] MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Eden_Space.norm                        thrpt   20   22751.138 ±   420.982    B/op
[info] MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Survivor_Space                         thrpt   20       0.113 ±     0.031  MB/sec
[info] MessageUnpackerBenchmark.decodeInt10:·gc.churn.PS_Survivor_Space.norm                    thrpt   20       0.610 ±     0.168    B/op
[info] MessageUnpackerBenchmark.decodeInt10:·gc.count                                           thrpt   20     359.000              counts
[info] MessageUnpackerBenchmark.decodeInt10:·gc.time                                            thrpt   20     195.000                  ms
[info] MessageUnpackerBenchmark.decodeInt30                                                     thrpt   20  130384.440 ±  5428.657   ops/s
[info] MessageUnpackerBenchmark.decodeInt30:·gc.alloc.rate                                      thrpt   20    2763.242 ±   115.100  MB/sec
[info] MessageUnpackerBenchmark.decodeInt30:·gc.alloc.rate.norm                                 thrpt   20   33384.013 ±    14.255    B/op
[info] MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Eden_Space                             thrpt   20    2777.200 ±   120.987  MB/sec
[info] MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Eden_Space.norm                        thrpt   20   33557.163 ±   635.819    B/op
[info] MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Survivor_Space                         thrpt   20       0.090 ±     0.029  MB/sec
[info] MessageUnpackerBenchmark.decodeInt30:·gc.churn.PS_Survivor_Space.norm                    thrpt   20       1.101 ±     0.380    B/op
[info] MessageUnpackerBenchmark.decodeInt30:·gc.count                                           thrpt   20     350.000              counts
[info] MessageUnpackerBenchmark.decodeInt30:·gc.time                                            thrpt   20     198.000                  ms
[info] MessageUnpackerBenchmark.decodeLong10                                                    thrpt   20  116669.811 ±  2423.805   ops/s
[info] MessageUnpackerBenchmark.decodeLong10:·gc.alloc.rate                                     thrpt   20    2646.816 ±    56.674  MB/sec
[info] MessageUnpackerBenchmark.decodeLong10:·gc.alloc.rate.norm                                thrpt   20   35736.014 ±    64.146    B/op
[info] MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Eden_Space                            thrpt   20    2642.477 ±    84.535  MB/sec
[info] MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Eden_Space.norm                       thrpt   20   35672.015 ±   645.005    B/op
[info] MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Survivor_Space                        thrpt   20       0.090 ±     0.031  MB/sec
[info] MessageUnpackerBenchmark.decodeLong10:·gc.churn.PS_Survivor_Space.norm                   thrpt   20       1.215 ±     0.410    B/op
[info] MessageUnpackerBenchmark.decodeLong10:·gc.count                                          thrpt   20     355.000              counts
[info] MessageUnpackerBenchmark.decodeLong10:·gc.time                                           thrpt   20     194.000                  ms
[info] MessageUnpackerBenchmark.decodeLong30                                                    thrpt   20   42903.651 ±  1197.532   ops/s
[info] MessageUnpackerBenchmark.decodeLong30:·gc.alloc.rate                                     thrpt   20    1942.318 ±    54.085  MB/sec
[info] MessageUnpackerBenchmark.decodeLong30:·gc.alloc.rate.norm                                thrpt   20   71308.038 ±    17.818    B/op
[info] MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Eden_Space                            thrpt   20    1951.366 ±    71.274  MB/sec
[info] MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Eden_Space.norm                       thrpt   20   71664.623 ±  2346.108    B/op
[info] MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Survivor_Space                        thrpt   20       0.070 ±     0.028  MB/sec
[info] MessageUnpackerBenchmark.decodeLong30:·gc.churn.PS_Survivor_Space.norm                   thrpt   20       2.580 ±     1.030    B/op
[info] MessageUnpackerBenchmark.decodeLong30:·gc.count                                          thrpt   20     293.000              counts
[info] MessageUnpackerBenchmark.decodeLong30:·gc.time                                           thrpt   20     177.000                  ms
[info] MessageUnpackerBenchmark.decodeNested                                                    thrpt   20  105284.983 ±  2737.642   ops/s
[info] MessageUnpackerBenchmark.decodeNested:·gc.alloc.rate                                     thrpt   20    2600.313 ±    68.488  MB/sec
[info] MessageUnpackerBenchmark.decodeNested:·gc.alloc.rate.norm                                thrpt   20   38904.016 ±    49.891    B/op
[info] MessageUnpackerBenchmark.decodeNested:·gc.churn.PS_Eden_Space                            thrpt   20    2604.148 ±   109.839  MB/sec
[info] MessageUnpackerBenchmark.decodeNested:·gc.churn.PS_Eden_Space.norm                       thrpt   20   38952.792 ±  1068.741    B/op
[info] MessageUnpackerBenchmark.decodeNested:·gc.churn.PS_Survivor_Space                        thrpt   20       0.089 ±     0.030  MB/sec
[info] MessageUnpackerBenchmark.decodeNested:·gc.churn.PS_Survivor_Space.norm                   thrpt   20       1.342 ±     0.470    B/op
[info] MessageUnpackerBenchmark.decodeNested:·gc.count                                          thrpt   20     321.000              counts
[info] MessageUnpackerBenchmark.decodeNested:·gc.time                                           thrpt   20     185.000                  ms
[info] MessageUnpackerBenchmark.decodeString1000_30                                             thrpt   20   35019.191 ±   808.341   ops/s
[info] MessageUnpackerBenchmark.decodeString1000_30:·gc.alloc.rate                              thrpt   20    2029.916 ±    46.501  MB/sec
[info] MessageUnpackerBenchmark.decodeString1000_30:·gc.alloc.rate.norm                         thrpt   20   91288.047 ±     7.128    B/op
[info] MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Eden_Space                     thrpt   20    2041.266 ±    85.780  MB/sec
[info] MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Eden_Space.norm                thrpt   20   91788.610 ±  3055.330    B/op
[info] MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Survivor_Space                 thrpt   20       0.158 ±     0.042  MB/sec
[info] MessageUnpackerBenchmark.decodeString1000_30:·gc.churn.PS_Survivor_Space.norm            thrpt   20       7.088 ±     1.889    B/op
[info] MessageUnpackerBenchmark.decodeString1000_30:·gc.count                                   thrpt   20     329.000              counts
[info] MessageUnpackerBenchmark.decodeString1000_30:·gc.time                                    thrpt   20     184.000                  ms
[info] MessageUnpackerBenchmark.decodeString1000_30_multibyte                                   thrpt   20    5053.968 ±    49.745   ops/s
[info] MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.alloc.rate                    thrpt   20    1224.975 ±    12.119  MB/sec
[info] MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.alloc.rate.norm               thrpt   20  381776.310 ±    17.157    B/op
[info] MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Eden_Space           thrpt   20    1227.391 ±    34.142  MB/sec
[info] MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Eden_Space.norm      thrpt   20  382538.009 ± 10154.078    B/op
[info] MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space       thrpt   20       0.219 ±     0.063  MB/sec
[info] MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.churn.PS_Survivor_Space.norm  thrpt   20      68.349 ±    19.565    B/op
[info] MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.count                         thrpt   20     304.000              counts
[info] MessageUnpackerBenchmark.decodeString1000_30_multibyte:·gc.time                          thrpt   20     165.000                  ms
[info] MessageUnpackerBenchmark.decodeString100_10                                              thrpt   20  221799.362 ±  4139.716   ops/s
[info] MessageUnpackerBenchmark.decodeString100_10:·gc.alloc.rate                               thrpt   20    3441.977 ±    65.248  MB/sec
[info] MessageUnpackerBenchmark.decodeString100_10:·gc.alloc.rate.norm                          thrpt   20   24472.007 ±     7.127    B/op
[info] MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Eden_Space                      thrpt   20    3438.706 ±   132.081  MB/sec
[info] MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Eden_Space.norm                 thrpt   20   24450.924 ±   861.124    B/op
[info] MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Survivor_Space                  thrpt   20       0.099 ±     0.029  MB/sec
[info] MessageUnpackerBenchmark.decodeString100_10:·gc.churn.PS_Survivor_Space.norm             thrpt   20       0.706 ±     0.209    B/op
[info] MessageUnpackerBenchmark.decodeString100_10:·gc.count                                    thrpt   20     333.000              counts
[info] MessageUnpackerBenchmark.decodeString100_10:·gc.time                                     thrpt   20     186.000                  ms
[info] MessageUnpackerBenchmark.decodeString100_30                                              thrpt   20   96945.679 ±  3381.020   ops/s
[info] MessageUnpackerBenchmark.decodeString100_30:·gc.alloc.rate                               thrpt   20    2403.940 ±    83.825  MB/sec
[info] MessageUnpackerBenchmark.decodeString100_30:·gc.alloc.rate.norm                          thrpt   20   39096.017 ±     0.034    B/op
[info] MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Eden_Space                      thrpt   20    2393.812 ±   116.042  MB/sec
[info] MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Eden_Space.norm                 thrpt   20   38924.539 ±  1196.855    B/op
[info] MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Survivor_Space                  thrpt   20       0.092 ±     0.037  MB/sec
[info] MessageUnpackerBenchmark.decodeString100_30:·gc.churn.PS_Survivor_Space.norm             thrpt   20       1.487 ±     0.577    B/op
[info] MessageUnpackerBenchmark.decodeString100_30:·gc.count                                    thrpt   20     340.000              counts
[info] MessageUnpackerBenchmark.decodeString100_30:·gc.time                                     thrpt   20     194.000                  ms
```